### PR TITLE
Fix "Never" option not working

### DIFF
--- a/src/MainGrid.vala
+++ b/src/MainGrid.vala
@@ -97,9 +97,7 @@ public class Badger.MainGrid : Gtk.Grid {
             scale.value_changed.connect (() => {
                 uint new_value = (uint) scale.get_value ();
                 settings.set_uint (reminder.name, new_value);
-                if (new_value > 0) {
-                    set_interval (new_value);
-                }
+                set_interval (new_value);
             });
 
             scale.format_value.connect (duration => {


### PR DESCRIPTION
Closes #19.

On sliding to "Never", `set_interval` wasn't being called, since the interval was 0. No need for that check, because 0 is already handled inside the `set_interval` method.