### PR TITLE
Move Global switch to header bar

### DIFF
--- a/src/MainGrid.vala
+++ b/src/MainGrid.vala
@@ -54,22 +54,12 @@ public class Badger.MainGrid : Gtk.Grid {
         margin_bottom = 12;
         orientation = Gtk.Orientation.VERTICAL;
 
-        var top = new Gtk.Grid ();
 
         var heading = new Gtk.Label (_ ("Reminders"));
         heading.halign = Gtk.Align.START;
         heading.hexpand = true;
         heading.get_style_context ().add_class (Granite.STYLE_CLASS_H2_LABEL);
-        top.attach (heading, 0, 0, 1, 1);
-
-        var global_switch = new Gtk.Switch ();
-        global_switch.halign = Gtk.Align.END;
-        global_switch.valign = Gtk.Align.CENTER;
-        top.attach (global_switch, 1, 0, 1, 1);
-
-        attach (top, 0, 0, 2, 1);
-
-        settings.bind ("all", global_switch, "active", SettingsBindFlags.DEFAULT);
+        attach (heading, 0, 0, 2, 1);
 
         var subheading = new Gtk.Label (_ ("Decide how often Badger should remind you to relax these:"));
         subheading.halign = Gtk.Align.START;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -51,6 +51,13 @@ public class Badger.MainWindow : Gtk.ApplicationWindow {
         header.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         header.get_style_context ().add_class ("badger-headerbar");
 
+        var global_switch = new Gtk.Switch ();
+        global_switch.halign = Gtk.Align.END;
+        global_switch.valign = Gtk.Align.CENTER;
+        var global_switch_settings = new GLib.Settings ("com.github.elfenware.badger.timers");
+        global_switch_settings.bind ("all", global_switch, "active", SettingsBindFlags.DEFAULT);
+
+        header.pack_end (global_switch);
         return header;
     }
 


### PR DESCRIPTION
I think the global switch should stay in the header, which looks much cleaner.

However, I don't actually know how to change the style of the switch, that, for now, has too little contrast.

![off](https://user-images.githubusercontent.com/49907041/66391940-bb837480-e9ce-11e9-8e54-34c6efd2a7ef.png)

![on](https://user-images.githubusercontent.com/49907041/66391950-c3431900-e9ce-11e9-807d-9ab56c53e994.png)

