### PR TITLE
Add per timer checkbox (#22)

### DIFF
--- a/data/gschema.xml
+++ b/data/gschema.xml
@@ -42,21 +42,41 @@
       <default>18</default>
       <summary>Timer (in minutes) to remind the user to blink their eyes</summary>
     </key>
+    <key name="eyes-active" type="b">
+      <default>true</default>
+      <summary>Whether to show the eyes reminders</summary>
+    </key>
     <key name="fingers" type="u">
       <default>38</default>
       <summary>Timer (in minutes) to remind the user to stretch their fingers</summary>
+    </key>
+    <key name="fingers-active" type="b">
+      <default>true</default>
+      <summary>Whether to show the fingers reminders</summary>
     </key>
     <key name="legs" type="u">
       <default>60</default>
       <summary>Timer (in minutes) to remind the user to stretch their legs</summary>
     </key>
+    <key name="legs-active" type="b">
+      <default>true</default>
+      <summary>Whether to show the legs reminders</summary>
+    </key>
     <key name="arms" type="u">
       <default>50</default>
       <summary>Timer (in minutes) to remind the user to stretch their arms</summary>
     </key>
+    <key name="arms-active" type="b">
+      <default>true</default>
+      <summary>Whether to show the arms reminders</summary>
+    </key>
     <key name="neck" type="u">
       <default>45</default>
       <summary>Timer (in minutes) to remind the user to turn their neck</summary>
+    </key>
+    <key name="neck-active" type="b">
+      <default>true</default>
+      <summary>Whether to show the neck reminders</summary>
     </key>
     <key name="old-settings-replaced" type="b">
       <default>false</default>

--- a/src/MainGrid.vala
+++ b/src/MainGrid.vala
@@ -84,12 +84,12 @@ public class Badger.MainGrid : Gtk.Grid {
             check_box.valign = Gtk.Align.START;
             check_box.margin_top = 24;
 
-            Gtk.Scale scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 60, 5);
+            Gtk.Scale scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 1, 60, 5);
             scale.hexpand = true;
             scale.width_request = 360;
             scale.margin_top = 24;
 
-            scale.add_mark (0, Gtk.PositionType.BOTTOM, _ ("Never"));
+            scale.add_mark (1, Gtk.PositionType.BOTTOM, _ ("1 min"));
             scale.add_mark (15, Gtk.PositionType.BOTTOM, null);
             scale.add_mark (30, Gtk.PositionType.BOTTOM, _ ("30 min"));
             scale.add_mark (45, Gtk.PositionType.BOTTOM, null);
@@ -108,16 +108,13 @@ public class Badger.MainGrid : Gtk.Grid {
             });
 
             scale.format_value.connect (duration => {
-                if (duration == 0) {
-                    return _ ("Never");
-                }
-
                 return _ ("%.0f min").printf (duration);
             });
 
             // If the "all" flag is false, disable all scales
-            settings.bind ("all", check_box, "sensitive", SettingsBindFlags.DEFAULT);
             settings.bind ("all", scale, "sensitive", SettingsBindFlags.DEFAULT);
+            
+            // settings.bind ("all", check_box, "sensitive", SettingsBindFlags.DEFAULT);
 
             settings.bind (reminder.name + "-active", check_box, "active", SettingsBindFlags.DEFAULT);
 

--- a/src/MainGrid.vala
+++ b/src/MainGrid.vala
@@ -119,6 +119,8 @@ public class Badger.MainGrid : Gtk.Grid {
             settings.bind ("all", check_box, "sensitive", SettingsBindFlags.DEFAULT);
             settings.bind ("all", scale, "sensitive", SettingsBindFlags.DEFAULT);
 
+            settings.bind (reminder.name + "-active", check_box, "active", SettingsBindFlags.DEFAULT);
+
             attach (check_box, 0, index + 2, 1, 1);
             attach (scale, 1, index + 2, 1, 1);
         }

--- a/src/MainGrid.vala
+++ b/src/MainGrid.vala
@@ -91,7 +91,7 @@ public class Badger.MainGrid : Gtk.Grid {
         global_switch.state_set.connect ((value) => {
             global_switch.set_active(value);
             scales.foreach ((key, scale) => {
-                scale.sensitive = value == true ? settings.get_boolean (key) : false;
+                scale.sensitive = value ? settings.get_boolean (key) : false;
             });
             
             // We don't care about handling the switch animation ourselves, so return false
@@ -118,7 +118,7 @@ public class Badger.MainGrid : Gtk.Grid {
             scale.add_mark (60, Gtk.PositionType.BOTTOM, _ ("1 hour"));
 
             // Get the scale default value
-            scale.sensitive = settings.get_boolean("all") == true ? settings.get_boolean(reminder.name + "-active") : false;
+            scale.sensitive = settings.get_boolean("all") ? settings.get_boolean(reminder.name + "-active") : false;
             
             scales.insert(reminder.name + "-active", scale);
 

--- a/src/MainGrid.vala
+++ b/src/MainGrid.vala
@@ -111,12 +111,12 @@ public class Badger.MainGrid : Gtk.Grid {
                 return _ ("%.0f min").printf (duration);
             });
 
-            // If the "all" flag is false, disable all scales
-            settings.bind ("all", scale, "sensitive", SettingsBindFlags.DEFAULT);
-            
-            // settings.bind ("all", check_box, "sensitive", SettingsBindFlags.DEFAULT);
+            // If the "all" flag is false, disable all scales and checkboxes
+            settings.bind ("all", scale, "sensitive", SettingsBindFlags.GET);
+            settings.bind ("all", check_box, "sensitive", SettingsBindFlags.GET);
 
-            settings.bind (reminder.name + "-active", check_box, "active", SettingsBindFlags.DEFAULT);
+            // When the checkbox is pressed, set the option.
+            settings.bind (reminder.name + "-active", check_box, "active", SettingsBindFlags.DEFAULT | SettingsBindFlags.NO_SENSITIVITY);
 
             attach (check_box, 0, index + 2, 1, 1);
             attach (scale, 1, index + 2, 1, 1);

--- a/src/MainGrid.vala
+++ b/src/MainGrid.vala
@@ -76,20 +76,15 @@ public class Badger.MainGrid : Gtk.Grid {
         subheading.margin_bottom = 12;
         attach (subheading, 0, 1, 2, 1);
 
-        var labels = new Gtk.Label[reminders.length];
-        var scales = new Gtk.Scale[reminders.length];
-
         for (int index = 0; index < reminders.length; index++) {
             Reminder reminder = reminders[index];
 
-            Gtk.Label label = labels[index] = new Gtk.Label (reminder.display_label);
-            label.halign = Gtk.Align.END;
-            label.valign = Gtk.Align.START;
-            label.xalign = 1;
-            label.width_request = 60;
-            label.margin_top = 24;
+            Gtk.CheckButton check_box = new Gtk.CheckButton.with_label (reminder.display_label);
+            check_box.halign = Gtk.Align.BASELINE;
+            check_box.valign = Gtk.Align.START;
+            check_box.margin_top = 24;
 
-            Gtk.Scale scale = scales[index] = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 60, 5);
+            Gtk.Scale scale = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 60, 5);
             scale.hexpand = true;
             scale.width_request = 360;
             scale.margin_top = 24;
@@ -121,10 +116,10 @@ public class Badger.MainGrid : Gtk.Grid {
             });
 
             // If the "all" flag is false, disable all scales
-            settings.bind ("all", label, "sensitive", SettingsBindFlags.DEFAULT);
+            settings.bind ("all", check_box, "sensitive", SettingsBindFlags.DEFAULT);
             settings.bind ("all", scale, "sensitive", SettingsBindFlags.DEFAULT);
 
-            attach (label, 0, index + 2, 1, 1);
+            attach (check_box, 0, index + 2, 1, 1);
             attach (scale, 1, index + 2, 1, 1);
         }
     }

--- a/src/MainGrid.vala
+++ b/src/MainGrid.vala
@@ -123,6 +123,17 @@ public class Badger.MainGrid : Gtk.Grid {
             scales.insert(reminder.name + "-active", scale);
 
             uint interval = settings.get_uint (reminder.name);
+            // Old settings migration: interval == 0 meant "never" till 2.3.1
+            if ( interval == 0 ) {
+                // Reset to default value
+                settings.reset (reminder.name);
+                
+                // Read interval again (interval = default_value)
+                interval = settings.get_uint (reminder.name);
+
+                // Uncheck the corresponding checkbox
+                settings.set_boolean (reminder.name + "-active", false);
+            }
             scale.set_value (interval);
 
             SetInterval set_interval = reminder.set_reminder_interval;

--- a/src/Reminder.vala
+++ b/src/Reminder.vala
@@ -51,8 +51,8 @@ public class Badger.Reminder : GLib.Object {
         notification.set_body (message);
 
         var settings = new GLib.Settings ("com.github.elfenware.badger.timers");
-        settings.bind ("all", this, "global_active", SettingsBindFlags.DEFAULT);
-        settings.bind (name + "-active", this, "checkbox_active", SettingsBindFlags.DEFAULT);
+        settings.bind ("all", this, "global_active", SettingsBindFlags.GET);
+        settings.bind (name + "-active", this, "checkbox_active", SettingsBindFlags.GET);
     }
 
     public void set_reminder_interval (uint new_interval) {

--- a/src/Reminder.vala
+++ b/src/Reminder.vala
@@ -27,7 +27,8 @@ public class Badger.Reminder : GLib.Object {
     public string message { get; set; }         // Notification body
     public string display_label { get; set; }   // UI label
     public uint interval { get; set; }          // Reminder interval
-    public bool active { get; set; }            // Whether to show the notification
+    public bool global_active { get; set; }     // Whether to show every notification
+    public bool checkbox_active { get; set; }   // Whether to show this notification
     public Gtk.Application app { get; set; }
 
     private Notification notification;
@@ -50,7 +51,8 @@ public class Badger.Reminder : GLib.Object {
         notification.set_body (message);
 
         var settings = new GLib.Settings ("com.github.elfenware.badger.timers");
-        settings.bind ("all", this, "active", SettingsBindFlags.DEFAULT);
+        settings.bind ("all", this, "global_active", SettingsBindFlags.DEFAULT);
+        settings.bind (name + "-active", this, "checkbox_active", SettingsBindFlags.DEFAULT);
     }
 
     public void set_reminder_interval (uint new_interval) {
@@ -68,7 +70,7 @@ public class Badger.Reminder : GLib.Object {
     }
 
     public bool remind () {
-        if (active) {
+        if (global_active && checkbox_active) {
             app.send_notification (name, notification);
         }
         return true;


### PR DESCRIPTION
## Working

Add a per timer checkbox in addition to the global switch (closes #22).

The notification logic works perfectly fine: a notification only appears if the global switch is active and if the corresponding checkbox is checked.

## Problems

Because of how the binding between the scales and the global switch works, there are still two minor front-end problems:

### Global switch off => checkboxes sensitive

![switchoff](https://user-images.githubusercontent.com/49907041/66700837-c4898400-ecf5-11e9-88d0-184a204e98af.png)

Since the checkboxes are bound to a new option property (_eyes-active, fingers-active_ [...]) they cannot be bound to the global switch '_all_' property.

### Checkbox unchecked && global switch on => Scale sensitive

![switchon](https://user-images.githubusercontent.com/49907041/66700905-4da0bb00-ecf6-11e9-8828-6e14407d13b0.png)

Same applies here, since the Scale _sensitive_ property is bound to the '_all_' property of the global switch, it cannot be controlled by the checkboxes.