### PR TITLE
Update app description and translations

### DIFF
--- a/data/com.github.elfenware.badger.appdata.xml.in
+++ b/data/com.github.elfenware.badger.appdata.xml.in
@@ -7,11 +7,11 @@
   <name>Badger</name>
   <summary>Remind yourself to not sit and stare at the screen for too long</summary>
   <description>
-    <p>Whether you're dashing through Mario Kart on MupenGUI, binge-watching Silicon Valley on Cinema, or writing your next novel on Quilter, you need to relax your body every once in a while.</p>
+    <p>When you are using your computer for extended periods of time, you need to relax your body every once in a while.</p>
 
     <p>Badger helps you do exactly that. It reminds you—or should I say, badgers you—to destress yourself and rest your eyes and muscles.</p>
 
-    <p>Currently, it has these five reminders:</p>
+    <p>Currently, it has these six reminders:</p>
 
     <ul>
       <li>Blink eyes</li>
@@ -19,11 +19,20 @@
       <li>Stretch arms</li>
       <li>Stretch legs</li>
       <li>Turn neck</li>
+      <li>Maintain posture</li>
     </ul>
 
     <p>Stay healthy.</p>
   </description>
   <releases>
+    <release version="4.1.0" date="2021-08-20">
+      <description>
+        <ul>
+          <li>Add: Czech translation (@pervoj)</li>
+          <li>Add: Italian translation (@albanobattistella)</li>
+        </ul>
+      </description>
+    </release>
     <release version="4.0.1" date="2021-08-06">
       <description>
         <p>Odin update 🎉️</p>

--- a/data/com.github.elfenware.badger.appdata.xml.in
+++ b/data/com.github.elfenware.badger.appdata.xml.in
@@ -60,7 +60,7 @@
       <description>
         <ul>
           <li>Add: Spanish translation (@fitojb)</li>
-          <li>Add: Ukrainian translation (@IgorHordiichuk)</li>
+          <li>Add: Ukrainian translation (@IhorHordiichuk)</li>
         </ul>
       </description>
     </release>

--- a/data/com.github.elfenware.badger.appdata.xml.in
+++ b/data/com.github.elfenware.badger.appdata.xml.in
@@ -28,8 +28,8 @@
     <release version="4.1.0" date="2021-08-20">
       <description>
         <ul>
-          <li>Add: Czech translation (@pervoj)</li>
-          <li>Add: Italian translation (@albanobattistella)</li>
+          <li>Add: Czech translations (@pervoj)</li>
+          <li>Add: Italian translations (@albanobattistella)</li>
         </ul>
       </description>
     </release>
@@ -52,15 +52,15 @@
     <release version="3.3.0" date="2020-08-25">
       <description>
         <ul>
-          <li>Add: Portuguese (Portugal) translation (@rottenpants466)</li>
+          <li>Add: Portuguese (Portugal) translations (@rottenpants466)</li>
         </ul>
       </description>
     </release>
     <release version="3.2.0" date="2020-05-31">
       <description>
         <ul>
-          <li>Add: Spanish translation (@fitojb)</li>
-          <li>Add: Ukrainian translation (@IhorHordiichuk)</li>
+          <li>Add: Spanish translations (@fitojb)</li>
+          <li>Add: Ukrainian translations (@IhorHordiichuk)</li>
         </ul>
       </description>
     </release>
@@ -104,14 +104,14 @@
     <release version="2.2.0" date="2019-09-26">
       <description>
         <ul>
-          <li>Add: Turkish translation (@libreajans)</li>
+          <li>Add: Turkish translations (@libreajans)</li>
         </ul>
       </description>
     </release>
     <release version="2.1.0" date="2019-07-12">
       <description>
         <ul>
-          <li>Add: Dutch translation (@Vistaus)</li>
+          <li>Add: Dutch translations (@Vistaus)</li>
         </ul>
       </description>
     </release>
@@ -135,8 +135,8 @@
     <release version="1.3.0" date="2019-03-30">
       <description>
         <ul>
-          <li>Add: Danish translation (@siigdev)</li>
-          <li>Update: French translation (@NathanBnm)</li>
+          <li>Add: Danish translations (@siigdev)</li>
+          <li>Update: French translations (@NathanBnm)</li>
         </ul>
       </description>
     </release>

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 # project name and programming language
-project('com.github.elfenware.badger', 'vala', 'c', version: '4.0.1')
+project('com.github.elfenware.badger', 'vala', 'c', version: '4.1.0')
 
 message('project name and programming language')
 

--- a/po/com.github.elfenware.badger.pot
+++ b/po/com.github.elfenware.badger.pot
@@ -210,7 +210,7 @@ msgid "Add: Spanish translation (@fitojb)"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
-msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgid "Add: Ukrainian translation (@IhorHordiichuk)"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70

--- a/po/com.github.elfenware.badger.pot
+++ b/po/com.github.elfenware.badger.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-20 22:35+0530\n"
+"POT-Creation-Date: 2021-08-21 11:58+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -184,11 +184,11 @@ msgid "Stay healthy."
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:31
-msgid "Add: Czech translation (@pervoj)"
+msgid "Add: Czech translations (@pervoj)"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:32
-msgid "Add: Italian translation (@albanobattistella)"
+msgid "Add: Italian translations (@albanobattistella)"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:38
@@ -202,15 +202,15 @@ msgid "Add: Dark style support"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:55
-msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgid "Add: Portuguese (Portugal) translations (@rottenpants466)"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:62
-msgid "Add: Spanish translation (@fitojb)"
+msgid "Add: Spanish translations (@fitojb)"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
-msgid "Add: Ukrainian translation (@IhorHordiichuk)"
+msgid "Add: Ukrainian translations (@IhorHordiichuk)"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70
@@ -239,11 +239,11 @@ msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:107
-msgid "Add: Turkish translation (@libreajans)"
+msgid "Add: Turkish translations (@libreajans)"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:114
-msgid "Add: Dutch translation (@Vistaus)"
+msgid "Add: Dutch translations (@Vistaus)"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:121
@@ -255,6 +255,7 @@ msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:129
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translations (@NathanBnm)"
 msgstr ""
 
@@ -267,11 +268,7 @@ msgid "Update: Danish translations (@siigdev)"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:138
-msgid "Add: Danish translation (@siigdev)"
-msgstr ""
-
-#: data/com.github.elfenware.badger.appdata.xml.in:139
-msgid "Update: French translation (@NathanBnm)"
+msgid "Add: Danish translations (@siigdev)"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:145

--- a/po/com.github.elfenware.badger.pot
+++ b/po/com.github.elfenware.badger.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-24 01:00+0530\n"
+"POT-Creation-Date: 2021-08-20 22:35+0530\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,99 +17,99 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/Application.vala:156
+#: src/Application.vala:164
 msgid "Blink your eyes"
 msgstr ""
 
-#: src/Application.vala:157
+#: src/Application.vala:165
 msgid "Look away from the screen and slowly blink your eyes for 10 seconds."
 msgstr ""
 
-#: src/Application.vala:158
+#: src/Application.vala:166
 msgid "Eyes:"
 msgstr ""
 
-#: src/Application.vala:163
+#: src/Application.vala:171
 msgid "Stretch your fingers"
 msgstr ""
 
-#: src/Application.vala:164
+#: src/Application.vala:172
 msgid "Spread out your palm wide, then close it into a fist. Repeat 5 times."
 msgstr ""
 
-#: src/Application.vala:165
+#: src/Application.vala:173
 msgid "Fingers:"
 msgstr ""
 
-#: src/Application.vala:170
+#: src/Application.vala:178
 msgid "Stretch your arms"
 msgstr ""
 
-#: src/Application.vala:171
+#: src/Application.vala:179
 msgid "Stretch your arms, and twist your wrists for 10 seconds."
 msgstr ""
 
-#: src/Application.vala:172
+#: src/Application.vala:180
 msgid "Arms:"
 msgstr ""
 
-#: src/Application.vala:177
+#: src/Application.vala:185
 msgid "Stretch your legs"
 msgstr ""
 
-#: src/Application.vala:178
+#: src/Application.vala:186
 msgid "Stand up, twist each ankle, and bend each knee."
 msgstr ""
 
-#: src/Application.vala:179
+#: src/Application.vala:187
 msgid "Legs:"
 msgstr ""
 
-#: src/Application.vala:184
+#: src/Application.vala:192
 msgid "Turn your neck"
 msgstr ""
 
-#: src/Application.vala:185
+#: src/Application.vala:193
 msgid "Turn your head in all directions. Repeat 3 times."
 msgstr ""
 
-#: src/Application.vala:186
+#: src/Application.vala:194
 msgid "Neck:"
 msgstr ""
 
-#: src/Application.vala:191
+#: src/Application.vala:199
 msgid "Watch your posture"
 msgstr ""
 
-#: src/Application.vala:192
+#: src/Application.vala:200
 msgid "Make sure your back is straight."
 msgstr ""
 
-#: src/Application.vala:193
+#: src/Application.vala:201
 msgid "Posture:"
 msgstr ""
 
-#: src/MainGrid.vala:59
+#: src/MainGrid.vala:55
 msgid "Reminders"
 msgstr ""
 
-#: src/MainGrid.vala:74
+#: src/MainGrid.vala:72
 msgid "Decide how often Badger should remind you to relax these:"
 msgstr ""
 
-#: src/MainGrid.vala:114
+#: src/MainGrid.vala:115
 msgid "1 min"
 msgstr ""
 
-#: src/MainGrid.vala:116
+#: src/MainGrid.vala:117
 msgid "30 min"
 msgstr ""
 
-#: src/MainGrid.vala:118
+#: src/MainGrid.vala:119
 msgid "1 hour"
 msgstr ""
 
-#: src/MainGrid.vala:149
+#: src/MainGrid.vala:150
 #, c-format
 msgid "%.0f min"
 msgstr ""
@@ -141,8 +141,7 @@ msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:10
 msgid ""
-"Whether you're dashing through Mario Kart on MupenGUI, binge-watching "
-"Silicon Valley on Cinema, or writing your next novel on Quilter, you need to "
+"When you are using your computer for extended periods of time, you need to "
 "relax your body every once in a while."
 msgstr ""
 
@@ -153,7 +152,7 @@ msgid ""
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:14
-msgid "Currently, it has these five reminders:"
+msgid "Currently, it has these six reminders:"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:17
@@ -176,86 +175,137 @@ msgstr ""
 msgid "Turn neck"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:24
+#: data/com.github.elfenware.badger.appdata.xml.in:22
+msgid "Maintain posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:25
 msgid "Stay healthy."
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:30
+#: data/com.github.elfenware.badger.appdata.xml.in:31
+msgid "Add: Czech translation (@pervoj)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:32
+msgid "Add: Italian translation (@albanobattistella)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:38
+#: data/com.github.elfenware.badger.appdata.xml.in:46
+msgid "Odin update 🎉️"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:40
+#: data/com.github.elfenware.badger.appdata.xml.in:48
+msgid "Add: Dark style support"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:55
+msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:62
+msgid "Add: Spanish translation (@fitojb)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:63
+msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:70
+#: data/com.github.elfenware.badger.appdata.xml.in:93
 msgid "Update: Screenshot"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:37
+#: data/com.github.elfenware.badger.appdata.xml.in:77
+msgid "Add: New reminder for correcting your posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:84
+msgid "Add: Checkboxes to toggle each timer (@andreasomaini)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:85
+msgid "Fix: Work correctly with the Notification Center (@nathanaelhoun)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:86
+msgid "Update: Improved icon"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:100
 msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:44
+#: data/com.github.elfenware.badger.appdata.xml.in:107
 msgid "Add: Turkish translation (@libreajans)"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:51
+#: data/com.github.elfenware.badger.appdata.xml.in:114
 msgid "Add: Dutch translation (@Vistaus)"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:58
+#: data/com.github.elfenware.badger.appdata.xml.in:121
 msgid "Fix: \"Never\" option not disabling the timer"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:65
+#: data/com.github.elfenware.badger.appdata.xml.in:128
 msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:66
+#: data/com.github.elfenware.badger.appdata.xml.in:129
 msgid "Update: French translations (@NathanBnm)"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:67
+#: data/com.github.elfenware.badger.appdata.xml.in:130
 msgid "Update: Lithuanian translations (@welaq)"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:68
+#: data/com.github.elfenware.badger.appdata.xml.in:131
 msgid "Update: Danish translations (@siigdev)"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:75
+#: data/com.github.elfenware.badger.appdata.xml.in:138
 msgid "Add: Danish translation (@siigdev)"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:76
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translation (@NathanBnm)"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:82
+#: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:87
+#: data/com.github.elfenware.badger.appdata.xml.in:150
 msgid "Add: Lithuanian translations (@welaq)"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:88
+#: data/com.github.elfenware.badger.appdata.xml.in:151
 msgid "Fix: Illegible heading in dark mode"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:93
+#: data/com.github.elfenware.badger.appdata.xml.in:156
 msgid "Add: French translations (@NathanBnm)"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:98
+#: data/com.github.elfenware.badger.appdata.xml.in:161
 msgid "Fix: Multiple notifications when window is opened &gt;1 times"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:103
+#: data/com.github.elfenware.badger.appdata.xml.in:166
 msgid "Fix: Remove manual line breaks from appdata"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:108
+#: data/com.github.elfenware.badger.appdata.xml.in:171
 msgid "Fix: Use smaller window size by default"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:113
+#: data/com.github.elfenware.badger.appdata.xml.in:176
 msgid "Initial Release 🎉️"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:149
+#: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-20 22:35+0530\n"
+"POT-Creation-Date: 2021-08-21 11:58+0200\n"
 "PO-Revision-Date: 2021-08-09 17:52+0200\n"
 "Last-Translator: Vojtěch Perník <translations@pervoj.cz>\n"
 "Language-Team: Czech <gnome-cs-list@gnome.org>\n"
@@ -194,12 +194,12 @@ msgstr "Zůstaňte zdraví."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:31
 #, fuzzy
-msgid "Add: Czech translation (@pervoj)"
+msgid "Add: Czech translations (@pervoj)"
 msgstr "Přidáno: Dánský překlad (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:32
 #, fuzzy
-msgid "Add: Italian translation (@albanobattistella)"
+msgid "Add: Italian translations (@albanobattistella)"
 msgstr "Přidáno: Litevský překlad (@welaq)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:38
@@ -213,17 +213,17 @@ msgid "Add: Dark style support"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:55
-msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgid "Add: Portuguese (Portugal) translations (@rottenpants466)"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:62
 #, fuzzy
-msgid "Add: Spanish translation (@fitojb)"
+msgid "Add: Spanish translations (@fitojb)"
 msgstr "Přidáno: Dánský překlad (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
 #, fuzzy
-msgid "Add: Ukrainian translation (@IhorHordiichuk)"
+msgid "Add: Ukrainian translations (@IhorHordiichuk)"
 msgstr "Přidáno: Dánský překlad (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70
@@ -252,11 +252,13 @@ msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
 msgstr "Přidáno: 🎉️ Globální přepínač pro vypnutí všech připomínek 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:107
-msgid "Add: Turkish translation (@libreajans)"
+#, fuzzy
+msgid "Add: Turkish translations (@libreajans)"
 msgstr "Přidáno: Turecký překlad (@libreajans)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:114
-msgid "Add: Dutch translation (@Vistaus)"
+#, fuzzy
+msgid "Add: Dutch translations (@Vistaus)"
 msgstr "Přidáno: Holandský překlad (@Vistaus)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:121
@@ -268,6 +270,7 @@ msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr "Přidáno: 🎉️ Nejočekávanější funkce, vlastní časovače! 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:129
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Aktualizováno: Francouzský překlad (@NathanBnm)"
 
@@ -280,12 +283,9 @@ msgid "Update: Danish translations (@siigdev)"
 msgstr "Aktualizováno: Dánský překlad (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:138
-msgid "Add: Danish translation (@siigdev)"
+#, fuzzy
+msgid "Add: Danish translations (@siigdev)"
 msgstr "Přidáno: Dánský překlad (@siigdev)"
-
-#: data/com.github.elfenware.badger.appdata.xml.in:139
-msgid "Update: French translation (@NathanBnm)"
-msgstr "Aktualizováno: Francouzský překlad (@NathanBnm)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
@@ -322,3 +322,6 @@ msgstr "První verze 🎉️"
 #: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"
+
+#~ msgid "Update: French translation (@NathanBnm)"
+#~ msgstr "Aktualizováno: Francouzský překlad (@NathanBnm)"

--- a/po/cs.po
+++ b/po/cs.po
@@ -223,7 +223,7 @@ msgstr "Přidáno: Dánský překlad (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
 #, fuzzy
-msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgid "Add: Ukrainian translation (@IhorHordiichuk)"
 msgstr "Přidáno: Dánský překlad (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-21 11:58+0200\n"
-"PO-Revision-Date: 2021-08-09 17:52+0200\n"
+"POT-Creation-Date: 2021-08-23 22:35+0200\n"
+"PO-Revision-Date: 2021-08-23 22:41+0200\n"
 "Last-Translator: Vojtěch Perník <translations@pervoj.cz>\n"
 "Language-Team: Czech <gnome-cs-list@gnome.org>\n"
 "Language: cs\n"
@@ -97,7 +97,7 @@ msgstr "Připomínky"
 
 #: src/MainGrid.vala:72
 msgid "Decide how often Badger should remind you to relax these:"
-msgstr "Rozhodněte, jak často by vám měl Jezevec připomínat, abyste uvolnili:"
+msgstr "Rozhodněte, jak často by vám měl Badger připomínat, abyste uvolnili:"
 
 #: src/MainGrid.vala:115
 msgid "1 min"
@@ -129,10 +129,6 @@ msgstr "Ergonomický upomínač"
 msgid "Remind yourself to relax your eyes and limbs"
 msgstr "Připomeňte si, že máte uvolnit oči a končetiny"
 
-#: data/com.github.elfenware.badger.desktop.in:8
-msgid "com.github.elfenware.badger"
-msgstr "com.github.elfenware.badger"
-
 #: data/com.github.elfenware.badger.desktop.in:11
 msgid "Ergonomics;Health;Eyes;Muscles;"
 msgstr "Ergonomie;Zdraví;Oči;Svaly;"
@@ -142,14 +138,10 @@ msgid "Remind yourself to not sit and stare at the screen for too long"
 msgstr "Připomeňte si, že nesmíte sedět a zírat na obrazovku příliš dlouho"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:10
-#, fuzzy
 msgid ""
 "When you are using your computer for extended periods of time, you need to "
 "relax your body every once in a while."
-msgstr ""
-"Ať už se projíždíte v Mario Kart na MupenGUI, nepřetržitě sledujete Silicon "
-"Valley v Cinema, nebo píšete svůj další román v Quilteru, musíte jednou za "
-"čas uvolnit své tělo."
+msgstr "Při dlouhodobé práci s počítačem je třeba jednou za čas uvolnit tělo."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:12
 msgid ""
@@ -160,9 +152,8 @@ msgstr ""
 "nechali odpočinout své oči a svaly."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:14
-#, fuzzy
 msgid "Currently, it has these six reminders:"
-msgstr "V současné době obsahuje těchto pět připomínek:"
+msgstr "V současné době obsahuje těchto šest připomínek:"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:17
 msgid "Blink eyes"
@@ -186,45 +177,41 @@ msgstr "Otočte krkem"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:22
 msgid "Maintain posture"
-msgstr ""
+msgstr "Udržování správného držení těla"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:25
 msgid "Stay healthy."
 msgstr "Zůstaňte zdraví."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:31
-#, fuzzy
 msgid "Add: Czech translations (@pervoj)"
-msgstr "Přidáno: Dánský překlad (@siigdev)"
+msgstr "Přidáno: Český překlad (@pervoj)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:32
-#, fuzzy
 msgid "Add: Italian translations (@albanobattistella)"
-msgstr "Přidáno: Litevský překlad (@welaq)"
+msgstr "Přidáno: Italský překlad (@albanobattistella)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:38
 #: data/com.github.elfenware.badger.appdata.xml.in:46
 msgid "Odin update 🎉️"
-msgstr ""
+msgstr "Aktualizace pro Odin 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:40
 #: data/com.github.elfenware.badger.appdata.xml.in:48
 msgid "Add: Dark style support"
-msgstr ""
+msgstr "Přidáno: Podpora tmavého režimu"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:55
 msgid "Add: Portuguese (Portugal) translations (@rottenpants466)"
-msgstr ""
+msgstr "Přidáno: Portugalský překlad (@rottenpants466)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:62
-#, fuzzy
 msgid "Add: Spanish translations (@fitojb)"
-msgstr "Přidáno: Dánský překlad (@siigdev)"
+msgstr "Přidáno: Španělský překlad (@fitojb)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
-#, fuzzy
 msgid "Add: Ukrainian translations (@IhorHordiichuk)"
-msgstr "Přidáno: Dánský překlad (@siigdev)"
+msgstr "Přidáno: Ukrajinský překlad (@IhorHordiichuk)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70
 #: data/com.github.elfenware.badger.appdata.xml.in:93
@@ -233,31 +220,31 @@ msgstr "Aktualizováno: Screenshot"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:77
 msgid "Add: New reminder for correcting your posture"
-msgstr ""
+msgstr "Přidáno: Nová připomínka pro správné držení těla"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:84
 msgid "Add: Checkboxes to toggle each timer (@andreasomaini)"
 msgstr ""
+"Přidáno: Zaškrtávací políčka pro vypínání/zapínání jednotlivých připomínek "
+"(@andreasomaini)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:85
 msgid "Fix: Work correctly with the Notification Center (@nathanaelhoun)"
-msgstr ""
+msgstr "Opraveno: Správná práce s Centrem oznámení (@nathanaelhoun)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:86
 msgid "Update: Improved icon"
-msgstr ""
+msgstr "Aktualizováno: Vylepšena ikona"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:100
 msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
 msgstr "Přidáno: 🎉️ Globální přepínač pro vypnutí všech připomínek 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:107
-#, fuzzy
 msgid "Add: Turkish translations (@libreajans)"
 msgstr "Přidáno: Turecký překlad (@libreajans)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:114
-#, fuzzy
 msgid "Add: Dutch translations (@Vistaus)"
 msgstr "Přidáno: Holandský překlad (@Vistaus)"
 
@@ -283,7 +270,6 @@ msgid "Update: Danish translations (@siigdev)"
 msgstr "Aktualizováno: Dánský překlad (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:138
-#, fuzzy
 msgid "Add: Danish translations (@siigdev)"
 msgstr "Přidáno: Dánský překlad (@siigdev)"
 
@@ -322,6 +308,9 @@ msgstr "První verze 🎉️"
 #: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"
+
+#~ msgid "com.github.elfenware.badger"
+#~ msgstr "com.github.elfenware.badger"
 
 #~ msgid "Update: French translation (@NathanBnm)"
 #~ msgstr "Aktualizováno: Francouzský překlad (@NathanBnm)"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-24 01:00+0530\n"
+"POT-Creation-Date: 2021-08-20 22:35+0530\n"
 "PO-Revision-Date: 2021-08-09 17:52+0200\n"
 "Last-Translator: Vojtěch Perník <translations@pervoj.cz>\n"
 "Language-Team: Czech <gnome-cs-list@gnome.org>\n"
@@ -18,100 +18,100 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2\n"
 "X-Generator: Gtranslator 40.0\n"
 
-#: src/Application.vala:156
+#: src/Application.vala:164
 msgid "Blink your eyes"
 msgstr "Mrkněte očima"
 
-#: src/Application.vala:157
+#: src/Application.vala:165
 msgid "Look away from the screen and slowly blink your eyes for 10 seconds."
 msgstr ""
 "Odvraťte pohled od obrazovky a pomalu mrkejte očima po dobu deseti sekund."
 
-#: src/Application.vala:158
+#: src/Application.vala:166
 msgid "Eyes:"
 msgstr "Oči:"
 
-#: src/Application.vala:163
+#: src/Application.vala:171
 msgid "Stretch your fingers"
 msgstr "Protáhněte prsty"
 
-#: src/Application.vala:164
+#: src/Application.vala:172
 msgid "Spread out your palm wide, then close it into a fist. Repeat 5 times."
 msgstr "Roztáhněte dlaň doširoka a pak ji sevřete v pěst. Opakujte pětkrát."
 
-#: src/Application.vala:165
+#: src/Application.vala:173
 msgid "Fingers:"
 msgstr "Prsty:"
 
-#: src/Application.vala:170
+#: src/Application.vala:178
 msgid "Stretch your arms"
 msgstr "Protáhněte ruce"
 
-#: src/Application.vala:171
+#: src/Application.vala:179
 msgid "Stretch your arms, and twist your wrists for 10 seconds."
 msgstr "Napněte paže a 10 sekund kruťte zápěstím."
 
-#: src/Application.vala:172
+#: src/Application.vala:180
 msgid "Arms:"
 msgstr "Ruce:"
 
-#: src/Application.vala:177
+#: src/Application.vala:185
 msgid "Stretch your legs"
 msgstr "Protáhněte nohy"
 
-#: src/Application.vala:178
+#: src/Application.vala:186
 msgid "Stand up, twist each ankle, and bend each knee."
 msgstr "Postavte se, zakruťte každým kotníkem a pokrčte každé koleno."
 
-#: src/Application.vala:179
+#: src/Application.vala:187
 msgid "Legs:"
 msgstr "Nohy:"
 
-#: src/Application.vala:184
+#: src/Application.vala:192
 msgid "Turn your neck"
 msgstr "Otočte krkem"
 
-#: src/Application.vala:185
+#: src/Application.vala:193
 msgid "Turn your head in all directions. Repeat 3 times."
 msgstr "Otáčejte hlavou všemi směry. Opakujte třikrát."
 
-#: src/Application.vala:186
+#: src/Application.vala:194
 msgid "Neck:"
 msgstr "Krk:"
 
-#: src/Application.vala:191
+#: src/Application.vala:199
 msgid "Watch your posture"
 msgstr "Sledujte své držení těla"
 
-#: src/Application.vala:192
+#: src/Application.vala:200
 msgid "Make sure your back is straight."
 msgstr "Ujistěte se, že máte rovná záda."
 
-#: src/Application.vala:193
+#: src/Application.vala:201
 msgid "Posture:"
 msgstr "Držení těla:"
 
-#: src/MainGrid.vala:59
+#: src/MainGrid.vala:55
 msgid "Reminders"
 msgstr "Připomínky"
 
-#: src/MainGrid.vala:74
+#: src/MainGrid.vala:72
 msgid "Decide how often Badger should remind you to relax these:"
 msgstr "Rozhodněte, jak často by vám měl Jezevec připomínat, abyste uvolnili:"
 
-#: src/MainGrid.vala:114
+#: src/MainGrid.vala:115
 msgid "1 min"
 msgstr "1 min"
 
-#: src/MainGrid.vala:116
+#: src/MainGrid.vala:117
 msgid "30 min"
 msgstr "30 min"
 
-#: src/MainGrid.vala:118
+#: src/MainGrid.vala:119
 msgid "1 hour"
 msgstr "1 hod"
 
-#: src/MainGrid.vala:149
+#: src/MainGrid.vala:150
 #, c-format
 msgid "%.0f min"
 msgstr "%.0f min"
@@ -142,9 +142,9 @@ msgid "Remind yourself to not sit and stare at the screen for too long"
 msgstr "Připomeňte si, že nesmíte sedět a zírat na obrazovku příliš dlouho"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:10
+#, fuzzy
 msgid ""
-"Whether you're dashing through Mario Kart on MupenGUI, binge-watching "
-"Silicon Valley on Cinema, or writing your next novel on Quilter, you need to "
+"When you are using your computer for extended periods of time, you need to "
 "relax your body every once in a while."
 msgstr ""
 "Ať už se projíždíte v Mario Kart na MupenGUI, nepřetržitě sledujete Silicon "
@@ -160,7 +160,8 @@ msgstr ""
 "nechali odpočinout své oči a svaly."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:14
-msgid "Currently, it has these five reminders:"
+#, fuzzy
+msgid "Currently, it has these six reminders:"
 msgstr "V současné době obsahuje těchto pět připomínek:"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:17
@@ -183,86 +184,141 @@ msgstr "Protáhněte nohy"
 msgid "Turn neck"
 msgstr "Otočte krkem"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:24
+#: data/com.github.elfenware.badger.appdata.xml.in:22
+msgid "Maintain posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:25
 msgid "Stay healthy."
 msgstr "Zůstaňte zdraví."
 
-#: data/com.github.elfenware.badger.appdata.xml.in:30
+#: data/com.github.elfenware.badger.appdata.xml.in:31
+#, fuzzy
+msgid "Add: Czech translation (@pervoj)"
+msgstr "Přidáno: Dánský překlad (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:32
+#, fuzzy
+msgid "Add: Italian translation (@albanobattistella)"
+msgstr "Přidáno: Litevský překlad (@welaq)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:38
+#: data/com.github.elfenware.badger.appdata.xml.in:46
+msgid "Odin update 🎉️"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:40
+#: data/com.github.elfenware.badger.appdata.xml.in:48
+msgid "Add: Dark style support"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:55
+msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:62
+#, fuzzy
+msgid "Add: Spanish translation (@fitojb)"
+msgstr "Přidáno: Dánský překlad (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:63
+#, fuzzy
+msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgstr "Přidáno: Dánský překlad (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:70
+#: data/com.github.elfenware.badger.appdata.xml.in:93
 msgid "Update: Screenshot"
 msgstr "Aktualizováno: Screenshot"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:37
+#: data/com.github.elfenware.badger.appdata.xml.in:77
+msgid "Add: New reminder for correcting your posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:84
+msgid "Add: Checkboxes to toggle each timer (@andreasomaini)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:85
+msgid "Fix: Work correctly with the Notification Center (@nathanaelhoun)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:86
+msgid "Update: Improved icon"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:100
 msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
 msgstr "Přidáno: 🎉️ Globální přepínač pro vypnutí všech připomínek 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:44
+#: data/com.github.elfenware.badger.appdata.xml.in:107
 msgid "Add: Turkish translation (@libreajans)"
 msgstr "Přidáno: Turecký překlad (@libreajans)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:51
+#: data/com.github.elfenware.badger.appdata.xml.in:114
 msgid "Add: Dutch translation (@Vistaus)"
 msgstr "Přidáno: Holandský překlad (@Vistaus)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:58
+#: data/com.github.elfenware.badger.appdata.xml.in:121
 msgid "Fix: \"Never\" option not disabling the timer"
 msgstr "Opraveno: Možnost \"Nikdy\" nevypíná časovač"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:65
+#: data/com.github.elfenware.badger.appdata.xml.in:128
 msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr "Přidáno: 🎉️ Nejočekávanější funkce, vlastní časovače! 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:66
+#: data/com.github.elfenware.badger.appdata.xml.in:129
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Aktualizováno: Francouzský překlad (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:67
+#: data/com.github.elfenware.badger.appdata.xml.in:130
 msgid "Update: Lithuanian translations (@welaq)"
 msgstr "Aktualizováno: Litevský překlad (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:68
+#: data/com.github.elfenware.badger.appdata.xml.in:131
 msgid "Update: Danish translations (@siigdev)"
 msgstr "Aktualizováno: Dánský překlad (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:75
+#: data/com.github.elfenware.badger.appdata.xml.in:138
 msgid "Add: Danish translation (@siigdev)"
 msgstr "Přidáno: Dánský překlad (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:76
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translation (@NathanBnm)"
 msgstr "Aktualizováno: Francouzský překlad (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:82
+#: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
 msgstr "Opraveno: Prázdné okno po spuštění"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:87
+#: data/com.github.elfenware.badger.appdata.xml.in:150
 msgid "Add: Lithuanian translations (@welaq)"
 msgstr "Přidáno: Litevský překlad (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:88
+#: data/com.github.elfenware.badger.appdata.xml.in:151
 msgid "Fix: Illegible heading in dark mode"
 msgstr "Opraveno: Nečitelný nadpis v tmavém režimu"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:93
+#: data/com.github.elfenware.badger.appdata.xml.in:156
 msgid "Add: French translations (@NathanBnm)"
 msgstr "Přidáno: Francouzský překlad (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:98
+#: data/com.github.elfenware.badger.appdata.xml.in:161
 msgid "Fix: Multiple notifications when window is opened &gt;1 times"
 msgstr "Opraveno: Vícenásobná oznámení při otevření okna &gt;1 krát"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:103
+#: data/com.github.elfenware.badger.appdata.xml.in:166
 msgid "Fix: Remove manual line breaks from appdata"
 msgstr "Opraveno: Odstranění ručního zalamování řádků z appdata"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:108
+#: data/com.github.elfenware.badger.appdata.xml.in:171
 msgid "Fix: Use smaller window size by default"
 msgstr "Opraveno: Použití menší velikosti okna ve výchozím nastavení"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:113
+#: data/com.github.elfenware.badger.appdata.xml.in:176
 msgid "Initial Release 🎉️"
 msgstr "První verze 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:149
+#: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"

--- a/po/da.po
+++ b/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-20 22:35+0530\n"
+"POT-Creation-Date: 2021-08-21 11:58+0200\n"
 "PO-Revision-Date: 2019-03-28 17:55+0100\n"
 "Last-Translator: siigdev\n"
 "Language-Team: \n"
@@ -192,12 +192,12 @@ msgstr "Forbliv sund."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:31
 #, fuzzy
-msgid "Add: Czech translation (@pervoj)"
+msgid "Add: Czech translations (@pervoj)"
 msgstr "Tilføj: Dansk oversættelse (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:32
 #, fuzzy
-msgid "Add: Italian translation (@albanobattistella)"
+msgid "Add: Italian translations (@albanobattistella)"
 msgstr "Tilføj: Litauisk oversættelse (@welaq)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:38
@@ -211,17 +211,17 @@ msgid "Add: Dark style support"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:55
-msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgid "Add: Portuguese (Portugal) translations (@rottenpants466)"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:62
 #, fuzzy
-msgid "Add: Spanish translation (@fitojb)"
+msgid "Add: Spanish translations (@fitojb)"
 msgstr "Tilføj: Dansk oversættelse (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
 #, fuzzy
-msgid "Add: Ukrainian translation (@IhorHordiichuk)"
+msgid "Add: Ukrainian translations (@IhorHordiichuk)"
 msgstr "Tilføj: Dansk oversættelse (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70
@@ -250,11 +250,13 @@ msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
 msgstr "Tilføjelse: 🎉️ Global knap til at slukke alle påmindelser 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:107
-msgid "Add: Turkish translation (@libreajans)"
+#, fuzzy
+msgid "Add: Turkish translations (@libreajans)"
 msgstr "Tilføj: Tyrkisk oversættelse (@libreajans)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:114
-msgid "Add: Dutch translation (@Vistaus)"
+#, fuzzy
+msgid "Add: Dutch translations (@Vistaus)"
 msgstr "Tilføj: Hollandsk oversættelse (@Vistaus)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:121
@@ -266,6 +268,7 @@ msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr "Tilføjelse: 🎉️ Mest ventede feature, personlige timere! 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:129
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Tilføj: Fransk oversættelse (@NathanBnm)"
 
@@ -280,12 +283,8 @@ msgstr "Tilføj: Dansk oversættelse (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:138
 #, fuzzy
-msgid "Add: Danish translation (@siigdev)"
+msgid "Add: Danish translations (@siigdev)"
 msgstr "Tilføj: Dansk oversættelse (@siigdev)"
-
-#: data/com.github.elfenware.badger.appdata.xml.in:139
-msgid "Update: French translation (@NathanBnm)"
-msgstr "Tilføj: Fransk oversættelse (@NathanBnm)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
@@ -322,6 +321,9 @@ msgstr "Første Release 🎉️"
 #: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"
+
+#~ msgid "Update: French translation (@NathanBnm)"
+#~ msgstr "Tilføj: Fransk oversættelse (@NathanBnm)"
 
 #~ msgid "Never"
 #~ msgstr "Aldrig"

--- a/po/da.po
+++ b/po/da.po
@@ -221,7 +221,7 @@ msgstr "Tilføj: Dansk oversættelse (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
 #, fuzzy
-msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgid "Add: Ukrainian translation (@IhorHordiichuk)"
 msgstr "Tilføj: Dansk oversættelse (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70

--- a/po/da.po
+++ b/po/da.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-24 01:00+0530\n"
+"POT-Creation-Date: 2021-08-20 22:35+0530\n"
 "PO-Revision-Date: 2019-03-28 17:55+0100\n"
 "Last-Translator: siigdev\n"
 "Language-Team: \n"
@@ -16,99 +16,99 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/Application.vala:156
+#: src/Application.vala:164
 msgid "Blink your eyes"
 msgstr "Blink med øjnene"
 
-#: src/Application.vala:157
+#: src/Application.vala:165
 msgid "Look away from the screen and slowly blink your eyes for 10 seconds."
 msgstr "Kig væk fra skærmen og blink langsomt øjnene i 10 sekunder"
 
-#: src/Application.vala:158
+#: src/Application.vala:166
 msgid "Eyes:"
 msgstr "Øjne:"
 
-#: src/Application.vala:163
+#: src/Application.vala:171
 msgid "Stretch your fingers"
 msgstr "Stræk dine fingre"
 
-#: src/Application.vala:164
+#: src/Application.vala:172
 msgid "Spread out your palm wide, then close it into a fist. Repeat 5 times."
 msgstr "Stræk din håndflade ud, og luk så til en knytnæve. Gentag 5 gange."
 
-#: src/Application.vala:165
+#: src/Application.vala:173
 msgid "Fingers:"
 msgstr "Fingre:"
 
-#: src/Application.vala:170
+#: src/Application.vala:178
 msgid "Stretch your arms"
 msgstr "Stræk dine arme"
 
-#: src/Application.vala:171
+#: src/Application.vala:179
 msgid "Stretch your arms, and twist your wrists for 10 seconds."
 msgstr "Stræk dine arme og drej dine håndled i 10 sekunder."
 
-#: src/Application.vala:172
+#: src/Application.vala:180
 msgid "Arms:"
 msgstr "Arme:"
 
-#: src/Application.vala:177
+#: src/Application.vala:185
 msgid "Stretch your legs"
 msgstr "Stræk dine ben"
 
-#: src/Application.vala:178
+#: src/Application.vala:186
 msgid "Stand up, twist each ankle, and bend each knee."
 msgstr "Rejs dig op, drej hver ankel og bøj knæene."
 
-#: src/Application.vala:179
+#: src/Application.vala:187
 msgid "Legs:"
 msgstr "Ben:"
 
-#: src/Application.vala:184
+#: src/Application.vala:192
 msgid "Turn your neck"
 msgstr "Drej din hals"
 
-#: src/Application.vala:185
+#: src/Application.vala:193
 msgid "Turn your head in all directions. Repeat 3 times."
 msgstr "Drej dit hoved i alle retninger. Gentag 3 gange."
 
-#: src/Application.vala:186
+#: src/Application.vala:194
 msgid "Neck:"
 msgstr "Hals:"
 
-#: src/Application.vala:191
+#: src/Application.vala:199
 msgid "Watch your posture"
 msgstr "Vær opmærksom på din kropsholdning"
 
-#: src/Application.vala:192
+#: src/Application.vala:200
 msgid "Make sure your back is straight."
 msgstr "Vær opmærksom på din ryg er lige"
 
-#: src/Application.vala:193
+#: src/Application.vala:201
 msgid "Posture:"
 msgstr "Kropsholdning:"
 
-#: src/MainGrid.vala:59
+#: src/MainGrid.vala:55
 msgid "Reminders"
 msgstr "Påmindelser"
 
-#: src/MainGrid.vala:74
+#: src/MainGrid.vala:72
 msgid "Decide how often Badger should remind you to relax these:"
 msgstr "Vælg hvor ofte du ønsker Badger skal minde dig om at slappe af:"
 
-#: src/MainGrid.vala:114
+#: src/MainGrid.vala:115
 msgid "1 min"
 msgstr "1 min"
 
-#: src/MainGrid.vala:116
+#: src/MainGrid.vala:117
 msgid "30 min"
 msgstr "30 min"
 
-#: src/MainGrid.vala:118
+#: src/MainGrid.vala:119
 msgid "1 hour"
 msgstr "1 time"
 
-#: src/MainGrid.vala:149
+#: src/MainGrid.vala:150
 #, c-format
 msgid "%.0f min"
 msgstr "%.0f min"
@@ -139,9 +139,9 @@ msgid "Remind yourself to not sit and stare at the screen for too long"
 msgstr "Mind dig selv om ikke at sidde og stirre på skærmen alt for længe"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:10
+#, fuzzy
 msgid ""
-"Whether you're dashing through Mario Kart on MupenGUI, binge-watching "
-"Silicon Valley on Cinema, or writing your next novel on Quilter, you need to "
+"When you are using your computer for extended periods of time, you need to "
 "relax your body every once in a while."
 msgstr ""
 "Om du suser gennem Mario Kart på MupenGUI, binge-watcher Silicon Valley i "
@@ -158,7 +158,8 @@ msgstr ""
 "øjne og muskler."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:14
-msgid "Currently, it has these five reminders:"
+#, fuzzy
+msgid "Currently, it has these six reminders:"
 msgstr "I øjeblikket har den disse fem påmindelser:"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:17
@@ -181,89 +182,144 @@ msgstr "Stræk benene"
 msgid "Turn neck"
 msgstr "Drej halsen"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:24
+#: data/com.github.elfenware.badger.appdata.xml.in:22
+msgid "Maintain posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:25
 msgid "Stay healthy."
 msgstr "Forbliv sund."
 
-#: data/com.github.elfenware.badger.appdata.xml.in:30
+#: data/com.github.elfenware.badger.appdata.xml.in:31
+#, fuzzy
+msgid "Add: Czech translation (@pervoj)"
+msgstr "Tilføj: Dansk oversættelse (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:32
+#, fuzzy
+msgid "Add: Italian translation (@albanobattistella)"
+msgstr "Tilføj: Litauisk oversættelse (@welaq)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:38
+#: data/com.github.elfenware.badger.appdata.xml.in:46
+msgid "Odin update 🎉️"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:40
+#: data/com.github.elfenware.badger.appdata.xml.in:48
+msgid "Add: Dark style support"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:55
+msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:62
+#, fuzzy
+msgid "Add: Spanish translation (@fitojb)"
+msgstr "Tilføj: Dansk oversættelse (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:63
+#, fuzzy
+msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgstr "Tilføj: Dansk oversættelse (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:70
+#: data/com.github.elfenware.badger.appdata.xml.in:93
 msgid "Update: Screenshot"
 msgstr "Opdatering: Screenshot"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:37
+#: data/com.github.elfenware.badger.appdata.xml.in:77
+msgid "Add: New reminder for correcting your posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:84
+msgid "Add: Checkboxes to toggle each timer (@andreasomaini)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:85
+msgid "Fix: Work correctly with the Notification Center (@nathanaelhoun)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:86
+msgid "Update: Improved icon"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:100
 msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
 msgstr "Tilføjelse: 🎉️ Global knap til at slukke alle påmindelser 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:44
+#: data/com.github.elfenware.badger.appdata.xml.in:107
 msgid "Add: Turkish translation (@libreajans)"
 msgstr "Tilføj: Tyrkisk oversættelse (@libreajans)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:51
+#: data/com.github.elfenware.badger.appdata.xml.in:114
 msgid "Add: Dutch translation (@Vistaus)"
 msgstr "Tilføj: Hollandsk oversættelse (@Vistaus)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:58
+#: data/com.github.elfenware.badger.appdata.xml.in:121
 msgid "Fix: \"Never\" option not disabling the timer"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:65
+#: data/com.github.elfenware.badger.appdata.xml.in:128
 msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr "Tilføjelse: 🎉️ Mest ventede feature, personlige timere! 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:66
+#: data/com.github.elfenware.badger.appdata.xml.in:129
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Tilføj: Fransk oversættelse (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:67
+#: data/com.github.elfenware.badger.appdata.xml.in:130
 msgid "Update: Lithuanian translations (@welaq)"
 msgstr "Tilføj: Litauisk oversættelse (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:68
+#: data/com.github.elfenware.badger.appdata.xml.in:131
 #, fuzzy
 msgid "Update: Danish translations (@siigdev)"
 msgstr "Tilføj: Dansk oversættelse (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:75
+#: data/com.github.elfenware.badger.appdata.xml.in:138
 #, fuzzy
 msgid "Add: Danish translation (@siigdev)"
 msgstr "Tilføj: Dansk oversættelse (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:76
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translation (@NathanBnm)"
 msgstr "Tilføj: Fransk oversættelse (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:82
+#: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
 msgstr "Fix: Tomt vindue ved start"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:87
+#: data/com.github.elfenware.badger.appdata.xml.in:150
 msgid "Add: Lithuanian translations (@welaq)"
 msgstr "Tilføj: Litauisk oversættelse (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:88
+#: data/com.github.elfenware.badger.appdata.xml.in:151
 msgid "Fix: Illegible heading in dark mode"
 msgstr "Fix: Ulæselig overskrift i dark mode"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:93
+#: data/com.github.elfenware.badger.appdata.xml.in:156
 msgid "Add: French translations (@NathanBnm)"
 msgstr "Tilføj: Fransk oversættelse (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:98
+#: data/com.github.elfenware.badger.appdata.xml.in:161
 msgid "Fix: Multiple notifications when window is opened &gt;1 times"
 msgstr "Fix: Flere meddelelser når vinduet er åbnet &gt;1 gange"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:103
+#: data/com.github.elfenware.badger.appdata.xml.in:166
 msgid "Fix: Remove manual line breaks from appdata"
 msgstr "Fix: Fjern manuelle linjeskift fra appdata"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:108
+#: data/com.github.elfenware.badger.appdata.xml.in:171
 msgid "Fix: Use smaller window size by default"
 msgstr "Fix: Mindre vinduestørrelse som standard "
 
-#: data/com.github.elfenware.badger.appdata.xml.in:113
+#: data/com.github.elfenware.badger.appdata.xml.in:176
 msgid "Initial Release 🎉️"
 msgstr "Første Release 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:149
+#: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,112 +7,112 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-24 01:00+0530\n"
-"PO-Revision-Date: 2020-05-28 12:40-0500\n"
+"POT-Creation-Date: 2021-08-20 22:35+0530\n"
+"PO-Revision-Date: 2021-08-20 22:37+0530\n"
+"Last-Translator: Adolfo Jayme Barrientos <fitojb@ubuntu.com>\n"
 "Language-Team: \n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.3.1\n"
-"Last-Translator: Adolfo Jayme Barrientos <fitojb@ubuntu.com>\n"
+"X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: es\n"
 
-#: src/Application.vala:156
+#: src/Application.vala:164
 msgid "Blink your eyes"
 msgstr "Parpadee"
 
-#: src/Application.vala:157
+#: src/Application.vala:165
 msgid "Look away from the screen and slowly blink your eyes for 10 seconds."
 msgstr "Aleje la vista de la pantalla y parpadee lentamente por 10 segundos."
 
-#: src/Application.vala:158
+#: src/Application.vala:166
 msgid "Eyes:"
 msgstr "Ojos:"
 
-#: src/Application.vala:163
+#: src/Application.vala:171
 msgid "Stretch your fingers"
 msgstr "Estire los dedos"
 
-#: src/Application.vala:164
+#: src/Application.vala:172
 msgid "Spread out your palm wide, then close it into a fist. Repeat 5 times."
 msgstr ""
 "Extienda la palma y ciérrela para hacer un puño. Repita el proceso cinco "
 "veces."
 
-#: src/Application.vala:165
+#: src/Application.vala:173
 msgid "Fingers:"
 msgstr "Dedos:"
 
-#: src/Application.vala:170
+#: src/Application.vala:178
 msgid "Stretch your arms"
 msgstr "Estire los brazos"
 
-#: src/Application.vala:171
+#: src/Application.vala:179
 msgid "Stretch your arms, and twist your wrists for 10 seconds."
 msgstr "Estire los brazos y gire las muñecas durante 10 segundos."
 
-#: src/Application.vala:172
+#: src/Application.vala:180
 msgid "Arms:"
 msgstr "Brazos:"
 
-#: src/Application.vala:177
+#: src/Application.vala:185
 msgid "Stretch your legs"
 msgstr "Estire las piernas"
 
-#: src/Application.vala:178
+#: src/Application.vala:186
 msgid "Stand up, twist each ankle, and bend each knee."
 msgstr "Párese, gire los tobillos y flexione las rodillas."
 
-#: src/Application.vala:179
+#: src/Application.vala:187
 msgid "Legs:"
 msgstr "Piernas:"
 
-#: src/Application.vala:184
+#: src/Application.vala:192
 msgid "Turn your neck"
 msgstr "Gire el cuello"
 
-#: src/Application.vala:185
+#: src/Application.vala:193
 msgid "Turn your head in all directions. Repeat 3 times."
 msgstr "Gire la cabeza en todas las direcciones. Repita el proceso tres veces."
 
-#: src/Application.vala:186
+#: src/Application.vala:194
 msgid "Neck:"
 msgstr "Cuello:"
 
-#: src/Application.vala:191
+#: src/Application.vala:199
 msgid "Watch your posture"
 msgstr "Vigile su postura"
 
-#: src/Application.vala:192
+#: src/Application.vala:200
 msgid "Make sure your back is straight."
 msgstr "Cerciórese de que su espalda esté recta."
 
-#: src/Application.vala:193
+#: src/Application.vala:201
 msgid "Posture:"
 msgstr "Postura:"
 
-#: src/MainGrid.vala:59
+#: src/MainGrid.vala:55
 msgid "Reminders"
 msgstr "Recordatorios"
 
-#: src/MainGrid.vala:74
+#: src/MainGrid.vala:72
 msgid "Decide how often Badger should remind you to relax these:"
 msgstr "Decida cuán seguido Badger debe recordarle relajarse:"
 
-#: src/MainGrid.vala:114
+#: src/MainGrid.vala:115
 msgid "1 min"
 msgstr "1 min"
 
-#: src/MainGrid.vala:116
+#: src/MainGrid.vala:117
 msgid "30 min"
 msgstr "30 min"
 
-#: src/MainGrid.vala:118
+#: src/MainGrid.vala:119
 msgid "1 hour"
 msgstr "1 h"
 
-#: src/MainGrid.vala:149
+#: src/MainGrid.vala:150
 #, c-format
 msgid "%.0f min"
 msgstr "%.0f min"
@@ -144,25 +144,23 @@ msgstr "Recuerde no permanecer sentado y mirando la pantalla demasiado tiempo"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:10
 msgid ""
-"Whether you're dashing through Mario Kart on MupenGUI, binge-watching "
-"Silicon Valley on Cinema, or writing your next novel on Quilter, you need to "
+"When you are using your computer for extended periods of time, you need to "
 "relax your body every once in a while."
 msgstr ""
-"Sin importar si está jugando al Mario Kart con MupenGUI, maratoneando "
-"Silicon Valley en Cinema o escribiendo su próxima novela con Quilter, "
-"necesita relajar el cuerpo de vez en cuando."
+"Cuando utiliza la computadora durante mucho tiempo, necesita relajar el "
+"cuerpo de vez en cuando."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:12
 msgid ""
-"Badger helps you do exactly that. It reminds you—or should I say, badgers you"
-"—to destress yourself and rest your eyes and muscles."
+"Badger helps you do exactly that. It reminds you—or should I say, badgers you—"
+"to destress yourself and rest your eyes and muscles."
 msgstr ""
 "Badger le ayuda a hacerlo. La aplicación le recuerda periódicamente "
 "desestresarse y descansar los ojos y los músculos."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:14
-msgid "Currently, it has these five reminders:"
-msgstr "Cuenta actualmente con estos cinco recordatorios:"
+msgid "Currently, it has these six reminders:"
+msgstr "Cuenta actualmente con estos seis recordatorios:"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:17
 msgid "Blink eyes"
@@ -184,88 +182,138 @@ msgstr "Estirar las piernas"
 msgid "Turn neck"
 msgstr "Girar el cuello"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:24
+#: data/com.github.elfenware.badger.appdata.xml.in:22
+msgid "Maintain posture"
+msgstr "Mantener la postura"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:25
 msgid "Stay healthy."
 msgstr "Permanezca saludable."
 
-#: data/com.github.elfenware.badger.appdata.xml.in:30
+#: data/com.github.elfenware.badger.appdata.xml.in:31
+msgid "Add: Czech translation (@pervoj)"
+msgstr "Adición: traducción en checo (@pervoj)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:32
+msgid "Add: Italian translation (@albanobattistella)"
+msgstr "Adición: traducción en italiano (@albanobattistella)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:38
+#: data/com.github.elfenware.badger.appdata.xml.in:46
+msgid "Odin update 🎉️"
+msgstr "Actualización para Odin 🎉️"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:40
+#: data/com.github.elfenware.badger.appdata.xml.in:48
+msgid "Add: Dark style support"
+msgstr "Adición: soporte de estilo oscuro"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:55
+msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgstr "Adición: traducción en portugués (@rottenpants466)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:62
+msgid "Add: Spanish translation (@fitojb)"
+msgstr "Adición: traducción en español (@fitojb)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:63
+msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgstr "Adición: traducción en ucraniano (@IgorHordiichuk)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:70
+#: data/com.github.elfenware.badger.appdata.xml.in:93
 msgid "Update: Screenshot"
 msgstr "Actualización: captura de pantalla"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:37
-msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
-msgstr ""
-"Adición: 🎉️ interruptor global para desactivar todos los recordatorios 🎉️"
+#: data/com.github.elfenware.badger.appdata.xml.in:77
+msgid "Add: New reminder for correcting your posture"
+msgstr "Adición: Nuevo recordatorio para corregir su postura"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:44
+#: data/com.github.elfenware.badger.appdata.xml.in:84
+msgid "Add: Checkboxes to toggle each timer (@andreasomaini)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:85
+msgid "Fix: Work correctly with the Notification Center (@nathanaelhoun)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:86
+msgid "Update: Improved icon"
+msgstr "Actualización: icono mejorado"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:100
+msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
+msgstr "Adición: 🎉️ interruptor global para desactivar todos los recordatorios 🎉️"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:107
 msgid "Add: Turkish translation (@libreajans)"
 msgstr "Adición: traducción en turco (@libreajans)."
 
-#: data/com.github.elfenware.badger.appdata.xml.in:51
+#: data/com.github.elfenware.badger.appdata.xml.in:114
 msgid "Add: Dutch translation (@Vistaus)"
 msgstr "Adición: traducción en neerlandés (@Vistaus)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:58
+#: data/com.github.elfenware.badger.appdata.xml.in:121
 msgid "Fix: \"Never\" option not disabling the timer"
 msgstr "Corrección: la opción «Nunca» no desactivaba el temporizador"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:65
+#: data/com.github.elfenware.badger.appdata.xml.in:128
 msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr "Adición: 🎉️ la función más anticipada, temporizadores personalizados 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:66
+#: data/com.github.elfenware.badger.appdata.xml.in:129
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Actualización: traducción en francés (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:67
+#: data/com.github.elfenware.badger.appdata.xml.in:130
 msgid "Update: Lithuanian translations (@welaq)"
 msgstr "Actualización: traducción en lituano (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:68
+#: data/com.github.elfenware.badger.appdata.xml.in:131
 msgid "Update: Danish translations (@siigdev)"
 msgstr "Actualización: traducción en danés (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:75
+#: data/com.github.elfenware.badger.appdata.xml.in:138
 msgid "Add: Danish translation (@siigdev)"
 msgstr "Adición: traducción en danés (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:76
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translation (@NathanBnm)"
 msgstr "Actualización: traducción en francés (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:82
+#: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
 msgstr "Corrección: ventana vacía al iniciar"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:87
+#: data/com.github.elfenware.badger.appdata.xml.in:150
 msgid "Add: Lithuanian translations (@welaq)"
 msgstr "Adición: traducción en lituano (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:88
+#: data/com.github.elfenware.badger.appdata.xml.in:151
 msgid "Fix: Illegible heading in dark mode"
 msgstr "Corrección: título invisible en el modo oscuro"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:93
+#: data/com.github.elfenware.badger.appdata.xml.in:156
 msgid "Add: French translations (@NathanBnm)"
 msgstr "Adición: traducción en francés (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:98
+#: data/com.github.elfenware.badger.appdata.xml.in:161
 msgid "Fix: Multiple notifications when window is opened &gt;1 times"
 msgstr ""
 "Corrección: múltiples notificaciones cuando la ventana se abre más de una vez"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:103
+#: data/com.github.elfenware.badger.appdata.xml.in:166
 msgid "Fix: Remove manual line breaks from appdata"
 msgstr "Corrección: eliminación de saltos de renglón manuales en appdata"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:108
+#: data/com.github.elfenware.badger.appdata.xml.in:171
 msgid "Fix: Use smaller window size by default"
 msgstr "Corrección: la ventana es más pequeña de manera predeterminada"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:113
+#: data/com.github.elfenware.badger.appdata.xml.in:176
 msgid "Initial Release 🎉️"
 msgstr "Publicación inicial 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:149
+#: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-20 22:35+0530\n"
+"POT-Creation-Date: 2021-08-21 11:58+0200\n"
 "PO-Revision-Date: 2021-08-20 22:37+0530\n"
 "Last-Translator: Adolfo Jayme Barrientos <fitojb@ubuntu.com>\n"
 "Language-Team: \n"
@@ -152,8 +152,8 @@ msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:12
 msgid ""
-"Badger helps you do exactly that. It reminds you—or should I say, badgers you—"
-"to destress yourself and rest your eyes and muscles."
+"Badger helps you do exactly that. It reminds you—or should I say, badgers you"
+"—to destress yourself and rest your eyes and muscles."
 msgstr ""
 "Badger le ayuda a hacerlo. La aplicación le recuerda periódicamente "
 "desestresarse y descansar los ojos y los músculos."
@@ -191,11 +191,13 @@ msgid "Stay healthy."
 msgstr "Permanezca saludable."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:31
-msgid "Add: Czech translation (@pervoj)"
+#, fuzzy
+msgid "Add: Czech translations (@pervoj)"
 msgstr "Adición: traducción en checo (@pervoj)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:32
-msgid "Add: Italian translation (@albanobattistella)"
+#, fuzzy
+msgid "Add: Italian translations (@albanobattistella)"
 msgstr "Adición: traducción en italiano (@albanobattistella)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:38
@@ -209,15 +211,18 @@ msgid "Add: Dark style support"
 msgstr "Adición: soporte de estilo oscuro"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:55
-msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+#, fuzzy
+msgid "Add: Portuguese (Portugal) translations (@rottenpants466)"
 msgstr "Adición: traducción en portugués (@rottenpants466)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:62
-msgid "Add: Spanish translation (@fitojb)"
+#, fuzzy
+msgid "Add: Spanish translations (@fitojb)"
 msgstr "Adición: traducción en español (@fitojb)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
-msgid "Add: Ukrainian translation (@IhorHordiichuk)"
+#, fuzzy
+msgid "Add: Ukrainian translations (@IhorHordiichuk)"
 msgstr "Adición: traducción en ucraniano (@IhorHordiichuk)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70
@@ -243,14 +248,17 @@ msgstr "Actualización: icono mejorado"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:100
 msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
-msgstr "Adición: 🎉️ interruptor global para desactivar todos los recordatorios 🎉️"
+msgstr ""
+"Adición: 🎉️ interruptor global para desactivar todos los recordatorios 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:107
-msgid "Add: Turkish translation (@libreajans)"
+#, fuzzy
+msgid "Add: Turkish translations (@libreajans)"
 msgstr "Adición: traducción en turco (@libreajans)."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:114
-msgid "Add: Dutch translation (@Vistaus)"
+#, fuzzy
+msgid "Add: Dutch translations (@Vistaus)"
 msgstr "Adición: traducción en neerlandés (@Vistaus)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:121
@@ -262,6 +270,7 @@ msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr "Adición: 🎉️ la función más anticipada, temporizadores personalizados 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:129
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Actualización: traducción en francés (@NathanBnm)"
 
@@ -274,12 +283,9 @@ msgid "Update: Danish translations (@siigdev)"
 msgstr "Actualización: traducción en danés (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:138
-msgid "Add: Danish translation (@siigdev)"
+#, fuzzy
+msgid "Add: Danish translations (@siigdev)"
 msgstr "Adición: traducción en danés (@siigdev)"
-
-#: data/com.github.elfenware.badger.appdata.xml.in:139
-msgid "Update: French translation (@NathanBnm)"
-msgstr "Actualización: traducción en francés (@NathanBnm)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
@@ -317,3 +323,6 @@ msgstr "Publicación inicial 🎉️"
 #: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"
+
+#~ msgid "Update: French translation (@NathanBnm)"
+#~ msgstr "Actualización: traducción en francés (@NathanBnm)"

--- a/po/es.po
+++ b/po/es.po
@@ -217,8 +217,8 @@ msgid "Add: Spanish translation (@fitojb)"
 msgstr "Adición: traducción en español (@fitojb)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
-msgid "Add: Ukrainian translation (@IgorHordiichuk)"
-msgstr "Adición: traducción en ucraniano (@IgorHordiichuk)"
+msgid "Add: Ukrainian translation (@IhorHordiichuk)"
+msgstr "Adición: traducción en ucraniano (@IhorHordiichuk)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70
 #: data/com.github.elfenware.badger.appdata.xml.in:93

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-29 18:05+0100\n"
+"POT-Creation-Date: 2021-08-20 22:35+0530\n"
 "PO-Revision-Date: 2019-03-14 11:57+0100\n"
 "Last-Translator: NathanBnm\n"
 "Language-Team: Français\n"
@@ -16,104 +16,104 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/Application.vala:156
+#: src/Application.vala:164
 msgid "Blink your eyes"
 msgstr "Clignez des yeux"
 
-#: src/Application.vala:157
+#: src/Application.vala:165
 msgid "Look away from the screen and slowly blink your eyes for 10 seconds."
 msgstr ""
 "Regardez en dehors de l'écran et clignez lentement des yeux pendant 10 "
 "secondes."
 
-#: src/Application.vala:158
+#: src/Application.vala:166
 msgid "Eyes:"
 msgstr "Yeux :"
 
-#: src/Application.vala:163
+#: src/Application.vala:171
 msgid "Stretch your fingers"
 msgstr "Étirez vos doigts"
 
-#: src/Application.vala:164
+#: src/Application.vala:172
 msgid "Spread out your palm wide, then close it into a fist. Repeat 5 times."
 msgstr ""
 "Étendez la paume de votre main, puis fermez-la en un poing. Répétez 5 fois."
 
-#: src/Application.vala:165
+#: src/Application.vala:173
 msgid "Fingers:"
 msgstr "Doigts :"
 
-#: src/Application.vala:170
+#: src/Application.vala:178
 msgid "Stretch your arms"
 msgstr "Étirez vos bras"
 
-#: src/Application.vala:171
+#: src/Application.vala:179
 msgid "Stretch your arms, and twist your wrists for 10 seconds."
 msgstr "Tendez les bras et tournez les poignets pendant 10 secondes."
 
-#: src/Application.vala:172
+#: src/Application.vala:180
 msgid "Arms:"
 msgstr "Bras :"
 
-#: src/Application.vala:177
+#: src/Application.vala:185
 msgid "Stretch your legs"
 msgstr "Étirez vos jambes"
 
-#: src/Application.vala:178
+#: src/Application.vala:186
 msgid "Stand up, twist each ankle, and bend each knee."
 msgstr "Levez-vous, tournez chaque cheville et pliez chaque genou."
 
-#: src/Application.vala:179
+#: src/Application.vala:187
 msgid "Legs:"
 msgstr "Jambes :"
 
-#: src/Application.vala:184
+#: src/Application.vala:192
 msgid "Turn your neck"
 msgstr "Tournez votre cou"
 
-#: src/Application.vala:185
+#: src/Application.vala:193
 msgid "Turn your head in all directions. Repeat 3 times."
 msgstr "Tournez votre tête dans toutes les directions. Répétez 3 fois."
 
-#: src/Application.vala:186
+#: src/Application.vala:194
 msgid "Neck:"
 msgstr "Cou :"
 
-#: src/Application.vala:191
+#: src/Application.vala:199
 msgid "Watch your posture"
 msgstr "Surveillez votre posture"
 
-#: src/Application.vala:192
+#: src/Application.vala:200
 msgid "Make sure your back is straight."
 msgstr "Assurez-vous que votre dos est droit."
 
-#: src/Application.vala:193
+#: src/Application.vala:201
 msgid "Posture:"
 msgstr "Posture :"
 
-#: src/MainGrid.vala:59
+#: src/MainGrid.vala:55
 msgid "Reminders"
 msgstr "Rappels"
 
-#: src/MainGrid.vala:74
+#: src/MainGrid.vala:72
 msgid "Decide how often Badger should remind you to relax these:"
 msgstr ""
 "Décidez de la fréquence à laquelle Badger doit vous rappeler de vous "
 "reposer :"
 
-#: src/MainGrid.vala:114
+#: src/MainGrid.vala:115
 msgid "1 min"
 msgstr "1 min"
 
-#: src/MainGrid.vala:116
+#: src/MainGrid.vala:117
 msgid "30 min"
 msgstr "30 min"
 
-#: src/MainGrid.vala:118
+#: src/MainGrid.vala:119
 msgid "1 hour"
 msgstr "1 heure"
 
-#: src/MainGrid.vala:149
+#: src/MainGrid.vala:150
 #, c-format
 msgid "%.0f min"
 msgstr "%.0f min"
@@ -146,9 +146,9 @@ msgstr ""
 "longtemps"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:10
+#, fuzzy
 msgid ""
-"Whether you're dashing through Mario Kart on MupenGUI, binge-watching "
-"Silicon Valley on Cinema, or writing your next novel on Quilter, you need to "
+"When you are using your computer for extended periods of time, you need to "
 "relax your body every once in a while."
 msgstr ""
 "Que vous soyez en train de vous défier à Mario Kart sur MupenGUI, regarder "
@@ -166,7 +166,8 @@ msgstr ""
 "yeux et les muscles."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:14
-msgid "Currently, it has these five reminders:"
+#, fuzzy
+msgid "Currently, it has these six reminders:"
 msgstr "Pour l'instant, il y a ces cinq rappels :"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:17
@@ -189,89 +190,144 @@ msgstr "Étirez vos jambes"
 msgid "Turn neck"
 msgstr "Tournez votre cou"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:24
+#: data/com.github.elfenware.badger.appdata.xml.in:22
+msgid "Maintain posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:25
 msgid "Stay healthy."
 msgstr "Restez en bonne santé."
 
-#: data/com.github.elfenware.badger.appdata.xml.in:30
+#: data/com.github.elfenware.badger.appdata.xml.in:31
+#, fuzzy
+msgid "Add: Czech translation (@pervoj)"
+msgstr "Ajout : Traductions en danois (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:32
+#, fuzzy
+msgid "Add: Italian translation (@albanobattistella)"
+msgstr "Ajout : Traductions en lituanien (@welaq)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:38
+#: data/com.github.elfenware.badger.appdata.xml.in:46
+msgid "Odin update 🎉️"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:40
+#: data/com.github.elfenware.badger.appdata.xml.in:48
+msgid "Add: Dark style support"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:55
+msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:62
+#, fuzzy
+msgid "Add: Spanish translation (@fitojb)"
+msgstr "Ajout : Traductions en danois (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:63
+#, fuzzy
+msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgstr "Ajout : Traductions en danois (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:70
+#: data/com.github.elfenware.badger.appdata.xml.in:93
 msgid "Update: Screenshot"
 msgstr "Mise à jour : Capture d'écran"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:37
+#: data/com.github.elfenware.badger.appdata.xml.in:77
+msgid "Add: New reminder for correcting your posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:84
+msgid "Add: Checkboxes to toggle each timer (@andreasomaini)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:85
+msgid "Fix: Work correctly with the Notification Center (@nathanaelhoun)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:86
+msgid "Update: Improved icon"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:100
 msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
 msgstr "Ajout : 🎉️ Activation/Désactivation de tous les rappels 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:44
+#: data/com.github.elfenware.badger.appdata.xml.in:107
 msgid "Add: Turkish translation (@libreajans)"
 msgstr "Ajout : Traductions en turque (@libreajans)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:51
+#: data/com.github.elfenware.badger.appdata.xml.in:114
 msgid "Add: Dutch translation (@Vistaus)"
 msgstr "Ajout : Traductions en néerlandais (@Vistaus)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:58
+#: data/com.github.elfenware.badger.appdata.xml.in:121
 msgid "Fix: \"Never\" option not disabling the timer"
 msgstr "Correction : L'option « Jamais » ne désactivait pas le chrono"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:65
+#: data/com.github.elfenware.badger.appdata.xml.in:128
 msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr ""
 "Ajout : 🎉️ La fonctionnalité la plus attendue, des chronos personnalisés ! 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:66
+#: data/com.github.elfenware.badger.appdata.xml.in:129
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Mise à jour : Traductions en français (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:67
+#: data/com.github.elfenware.badger.appdata.xml.in:130
 msgid "Update: Lithuanian translations (@welaq)"
 msgstr "Mise à jour : Traductions en lituanien (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:68
+#: data/com.github.elfenware.badger.appdata.xml.in:131
 msgid "Update: Danish translations (@siigdev)"
 msgstr "Mise à jour : Traductions en danois (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:75
+#: data/com.github.elfenware.badger.appdata.xml.in:138
 msgid "Add: Danish translation (@siigdev)"
 msgstr "Ajout : Traductions en danois (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:76
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translation (@NathanBnm)"
 msgstr "Mise à jour : Traductions en français (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:82
+#: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
 msgstr "Correction : Fenêtre vide au démarrage"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:87
+#: data/com.github.elfenware.badger.appdata.xml.in:150
 msgid "Add: Lithuanian translations (@welaq)"
 msgstr "Ajout : Traductions en lituanien (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:88
+#: data/com.github.elfenware.badger.appdata.xml.in:151
 msgid "Fix: Illegible heading in dark mode"
 msgstr "Correction : Titre illisible en mode sombre"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:93
+#: data/com.github.elfenware.badger.appdata.xml.in:156
 msgid "Add: French translations (@NathanBnm)"
 msgstr "Ajout : Traductions en français (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:98
+#: data/com.github.elfenware.badger.appdata.xml.in:161
 msgid "Fix: Multiple notifications when window is opened &gt;1 times"
 msgstr ""
 "Correction : Il y avait des notifications en double si l'application était "
 "ouverte plus d'une fois"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:103
+#: data/com.github.elfenware.badger.appdata.xml.in:166
 msgid "Fix: Remove manual line breaks from appdata"
 msgstr "Correction : Retrait des retours manuels à la ligne dans appdata"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:108
+#: data/com.github.elfenware.badger.appdata.xml.in:171
 msgid "Fix: Use smaller window size by default"
 msgstr "Correction : Fenêtre plus petite par défaut"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:113
+#: data/com.github.elfenware.badger.appdata.xml.in:176
 msgid "Initial Release 🎉️"
 msgstr "Version initiale 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:149
+#: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"

--- a/po/fr.po
+++ b/po/fr.po
@@ -229,7 +229,7 @@ msgstr "Ajout : Traductions en danois (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
 #, fuzzy
-msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgid "Add: Ukrainian translation (@IhorHordiichuk)"
 msgstr "Ajout : Traductions en danois (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70

--- a/po/fr.po
+++ b/po/fr.po
@@ -1,15 +1,15 @@
 # French translations for the com.github.elfenware.badger package.
-# Copyright (C) 2019 THE com.github.elfenware.badger'S COPYRIGHT HOLDER
+# Copyright (C) 2021 THE com.github.elfenware.badger'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the com.github.elfenware.badger package.
-# NathanBnm, 2019.
+# Nathan Bonnemaisn (@NathanBnm), 2021.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-20 22:35+0530\n"
-"PO-Revision-Date: 2019-03-14 11:57+0100\n"
-"Last-Translator: NathanBnm\n"
+"POT-Creation-Date: 2021-08-21 11:58+0200\n"
+"PO-Revision-Date: 2021-08-21 11:46+0200\n"
+"Last-Translator: Nathan Bonnemaisn (@NathanBnm)\n"
 "Language-Team: Français\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
@@ -146,15 +146,12 @@ msgstr ""
 "longtemps"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:10
-#, fuzzy
 msgid ""
 "When you are using your computer for extended periods of time, you need to "
 "relax your body every once in a while."
 msgstr ""
-"Que vous soyez en train de vous défier à Mario Kart sur MupenGUI, regarder "
-"des vidéos sur la Silicon Valley sur Cinema, ou entrain d'écrire votre "
-"prochain roman sur Quilter, vous avez besoin de vous détendre de temps à "
-"autre."
+"Lorsque vous utilisez votre ordinateur pendant de longues périodes, vous "
+"devez détendre votre corps de temps en temps."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:12
 msgid ""
@@ -166,9 +163,8 @@ msgstr ""
 "yeux et les muscles."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:14
-#, fuzzy
 msgid "Currently, it has these six reminders:"
-msgstr "Pour l'instant, il y a ces cinq rappels :"
+msgstr "Pour l'instant, il y a ces six rappels :"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:17
 msgid "Blink eyes"
@@ -192,45 +188,41 @@ msgstr "Tournez votre cou"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:22
 msgid "Maintain posture"
-msgstr ""
+msgstr "Maintenez votre posture"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:25
 msgid "Stay healthy."
 msgstr "Restez en bonne santé."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:31
-#, fuzzy
-msgid "Add: Czech translation (@pervoj)"
-msgstr "Ajout : Traductions en danois (@siigdev)"
+msgid "Add: Czech translations (@pervoj)"
+msgstr "Ajout : Traductions en tchèque (@pervoj)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:32
-#, fuzzy
-msgid "Add: Italian translation (@albanobattistella)"
-msgstr "Ajout : Traductions en lituanien (@welaq)"
+msgid "Add: Italian translations (@albanobattistella)"
+msgstr "Ajout : Traductions en italien (@albanobattistella)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:38
 #: data/com.github.elfenware.badger.appdata.xml.in:46
 msgid "Odin update 🎉️"
-msgstr ""
+msgstr "Mise à jour pour Odin 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:40
 #: data/com.github.elfenware.badger.appdata.xml.in:48
 msgid "Add: Dark style support"
-msgstr ""
+msgstr "Ajout : Prise en charge du thème sombre"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:55
-msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
-msgstr ""
+msgid "Add: Portuguese (Portugal) translations (@rottenpants466)"
+msgstr "Ajout : Traductions en portugais du Portugal (@rottenpants466)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:62
-#, fuzzy
-msgid "Add: Spanish translation (@fitojb)"
-msgstr "Ajout : Traductions en danois (@siigdev)"
+msgid "Add: Spanish translations (@fitojb)"
+msgstr "Ajout : Traductions en espagnol (@fitojb)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
-#, fuzzy
-msgid "Add: Ukrainian translation (@IhorHordiichuk)"
-msgstr "Ajout : Traductions en danois (@siigdev)"
+msgid "Add: Ukrainian translations (@IhorHordiichuk)"
+msgstr "Ajout : Traductions en ukrainien (@IhorHordiichuk)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70
 #: data/com.github.elfenware.badger.appdata.xml.in:93
@@ -239,42 +231,48 @@ msgstr "Mise à jour : Capture d'écran"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:77
 msgid "Add: New reminder for correcting your posture"
-msgstr ""
+msgstr "Ajout : Nouveau rappel pour corriger votre posture"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:84
 msgid "Add: Checkboxes to toggle each timer (@andreasomaini)"
 msgstr ""
+"Ajout : Cases à cocher pour activer/désactiver chaque minuteur "
+"(@andreasomaini)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:85
 msgid "Fix: Work correctly with the Notification Center (@nathanaelhoun)"
 msgstr ""
+"Correction : Meilleur intégration avec le centre de notifications "
+"(@nathanaelhoun)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:86
 msgid "Update: Improved icon"
-msgstr ""
+msgstr "Mise à jour : Amélioration de l'icône"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:100
 msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
-msgstr "Ajout : 🎉️ Activation/Désactivation de tous les rappels 🎉️"
+msgstr ""
+"Ajout : 🎉️ Paramètres global d'activation/désactivation de tous les rappels 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:107
-msgid "Add: Turkish translation (@libreajans)"
-msgstr "Ajout : Traductions en turque (@libreajans)"
+msgid "Add: Turkish translations (@libreajans)"
+msgstr "Ajout : Traductions en turc (@libreajans)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:114
-msgid "Add: Dutch translation (@Vistaus)"
+msgid "Add: Dutch translations (@Vistaus)"
 msgstr "Ajout : Traductions en néerlandais (@Vistaus)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:121
 msgid "Fix: \"Never\" option not disabling the timer"
-msgstr "Correction : L'option « Jamais » ne désactivait pas le chrono"
+msgstr "Correction : L'option « Jamais » ne désactivait pas le minuteur"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:128
 msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr ""
-"Ajout : 🎉️ La fonctionnalité la plus attendue, des chronos personnalisés ! 🎉️"
+"Ajout : 🎉️ La fonctionnalité la plus attendue, des minuteurs personnalisés ! 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:129
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Mise à jour : Traductions en français (@NathanBnm)"
 
@@ -287,12 +285,8 @@ msgid "Update: Danish translations (@siigdev)"
 msgstr "Mise à jour : Traductions en danois (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:138
-msgid "Add: Danish translation (@siigdev)"
+msgid "Add: Danish translations (@siigdev)"
 msgstr "Ajout : Traductions en danois (@siigdev)"
-
-#: data/com.github.elfenware.badger.appdata.xml.in:139
-msgid "Update: French translation (@NathanBnm)"
-msgstr "Mise à jour : Traductions en français (@NathanBnm)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
@@ -304,7 +298,7 @@ msgstr "Ajout : Traductions en lituanien (@welaq)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:151
 msgid "Fix: Illegible heading in dark mode"
-msgstr "Correction : Titre illisible en mode sombre"
+msgstr "Correction : Titre illisible avec le thème sombre"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:156
 msgid "Add: French translations (@NathanBnm)"
@@ -318,7 +312,8 @@ msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:166
 msgid "Fix: Remove manual line breaks from appdata"
-msgstr "Correction : Retrait des retours manuels à la ligne dans appdata"
+msgstr ""
+"Correction : Retrait des retours à la ligne manuels dans les métadonnées"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:171
 msgid "Fix: Use smaller window size by default"

--- a/po/it.po
+++ b/po/it.po
@@ -7,111 +7,113 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-24 01:00+0530\n"
+"POT-Creation-Date: 2021-08-20 22:35+0530\n"
 "PO-Revision-Date: 2021-08-11 10:40-0200\n"
+"Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language-Team: Italian\n"
+"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3.1\n"
-"Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: it\n"
 
-#: src/Application.vala:156
+#: src/Application.vala:164
 msgid "Blink your eyes"
 msgstr "Sbatti le palpebre"
 
-#: src/Application.vala:157
+#: src/Application.vala:165
 msgid "Look away from the screen and slowly blink your eyes for 10 seconds."
-msgstr "Distogli lo sguardo dallo schermo e sbatti lentamente gli occhi per 10 secondi."
+msgstr ""
+"Distogli lo sguardo dallo schermo e sbatti lentamente gli occhi per 10 "
+"secondi."
 
-#: src/Application.vala:158
+#: src/Application.vala:166
 msgid "Eyes:"
 msgstr "Occhi:"
 
-#: src/Application.vala:163
+#: src/Application.vala:171
 msgid "Stretch your fingers"
 msgstr "Allunga le dita"
 
-#: src/Application.vala:164
+#: src/Application.vala:172
 msgid "Spread out your palm wide, then close it into a fist. Repeat 5 times."
 msgstr ""
 "Allarga il palmo della mano, quindi chiudilo a pugno. Ripetere 5 volte."
 
-#: src/Application.vala:165
+#: src/Application.vala:173
 msgid "Fingers:"
 msgstr "Dita:"
 
-#: src/Application.vala:170
+#: src/Application.vala:178
 msgid "Stretch your arms"
 msgstr "Allunga le braccia"
 
-#: src/Application.vala:171
+#: src/Application.vala:179
 msgid "Stretch your arms, and twist your wrists for 10 seconds."
 msgstr "Allunga le braccia e ruota i polsi per 10 secondi."
 
-#: src/Application.vala:172
+#: src/Application.vala:180
 msgid "Arms:"
 msgstr "Braccia:"
 
-#: src/Application.vala:177
+#: src/Application.vala:185
 msgid "Stretch your legs"
 msgstr "Allunga le gambe"
 
-#: src/Application.vala:178
+#: src/Application.vala:186
 msgid "Stand up, twist each ankle, and bend each knee."
 msgstr "Alzati, ruota ogni caviglia e piega ogni ginocchio."
 
-#: src/Application.vala:179
+#: src/Application.vala:187
 msgid "Legs:"
 msgstr "Gambe:"
 
-#: src/Application.vala:184
+#: src/Application.vala:192
 msgid "Turn your neck"
 msgstr "Gira il collo"
 
-#: src/Application.vala:185
+#: src/Application.vala:193
 msgid "Turn your head in all directions. Repeat 3 times."
 msgstr "Gira la testa in tutte le direzioni. Ripetere 3 volte."
 
-#: src/Application.vala:186
+#: src/Application.vala:194
 msgid "Neck:"
 msgstr "Collo:"
 
-#: src/Application.vala:191
+#: src/Application.vala:199
 msgid "Watch your posture"
 msgstr "Guarda la tua postura"
 
-#: src/Application.vala:192
+#: src/Application.vala:200
 msgid "Make sure your back is straight."
 msgstr "Assicurati che la schiena sia dritta."
 
-#: src/Application.vala:193
+#: src/Application.vala:201
 msgid "Posture:"
 msgstr "Postura:"
 
-#: src/MainGrid.vala:59
+#: src/MainGrid.vala:55
 msgid "Reminders"
 msgstr "Promemoria"
 
-#: src/MainGrid.vala:74
+#: src/MainGrid.vala:72
 msgid "Decide how often Badger should remind you to relax these:"
 msgstr "Decidi quanto spesso Badger dovrebbe ricordarti di rilassarti:"
 
-#: src/MainGrid.vala:114
+#: src/MainGrid.vala:115
 msgid "1 min"
 msgstr "1 min"
 
-#: src/MainGrid.vala:116
+#: src/MainGrid.vala:117
 msgid "30 min"
 msgstr "30 min"
 
-#: src/MainGrid.vala:118
+#: src/MainGrid.vala:119
 msgid "1 hour"
 msgstr "1 h"
 
-#: src/MainGrid.vala:149
+#: src/MainGrid.vala:150
 #, c-format
 msgid "%.0f min"
 msgstr "%.0f min"
@@ -142,25 +144,27 @@ msgid "Remind yourself to not sit and stare at the screen for too long"
 msgstr "Ricorda a te stesso di non sederti e fissare lo schermo troppo a lungo"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:10
+#, fuzzy
 msgid ""
-"Whether you're dashing through Mario Kart on MupenGUI, binge-watching "
-"Silicon Valley on Cinema, or writing your next novel on Quilter, you need to "
+"When you are using your computer for extended periods of time, you need to "
 "relax your body every once in a while."
 msgstr ""
-"Indipendentemente dal fatto che tu tia giocando a Mario Kart con l'interfaccia grafica di Mupen, "
-"facendo una maratona Silycon Valley nel cinema o scrivendo il tuo prossimo romanzo con Quilter,"
-"hai bisogno di rilassare il tuo corpo di tanto in tanto."
+"Indipendentemente dal fatto che tu tia giocando a Mario Kart con "
+"l'interfaccia grafica di Mupen, facendo una maratona Silycon Valley nel "
+"cinema o scrivendo il tuo prossimo romanzo con Quilter,hai bisogno di "
+"rilassare il tuo corpo di tanto in tanto."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:12
 msgid ""
 "Badger helps you do exactly that. It reminds you—or should I say, badgers you"
 "—to destress yourself and rest your eyes and muscles."
 msgstr ""
-"Badger ti aiuta a fare esattamente questo. Ti ricorda, o dovrei dire, ti tormenta"
-"—per rilassarti e riposare gli occhi e i muscoli."
+"Badger ti aiuta a fare esattamente questo. Ti ricorda, o dovrei dire, ti "
+"tormenta—per rilassarti e riposare gli occhi e i muscoli."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:14
-msgid "Currently, it has these five reminders:"
+#, fuzzy
+msgid "Currently, it has these six reminders:"
 msgstr "Attualmente, ha questi cinque promemoria:"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:17
@@ -183,88 +187,143 @@ msgstr "Allunga le gambe"
 msgid "Turn neck"
 msgstr "Gira il collo"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:24
+#: data/com.github.elfenware.badger.appdata.xml.in:22
+msgid "Maintain posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:25
 msgid "Stay healthy."
 msgstr "Rimani in salute."
 
-#: data/com.github.elfenware.badger.appdata.xml.in:30
+#: data/com.github.elfenware.badger.appdata.xml.in:31
+#, fuzzy
+msgid "Add: Czech translation (@pervoj)"
+msgstr "Aggiunto: traduzione in danese (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:32
+#, fuzzy
+msgid "Add: Italian translation (@albanobattistella)"
+msgstr "Aggiunto: traduzione in lituano (@welaq)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:38
+#: data/com.github.elfenware.badger.appdata.xml.in:46
+msgid "Odin update 🎉️"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:40
+#: data/com.github.elfenware.badger.appdata.xml.in:48
+msgid "Add: Dark style support"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:55
+msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:62
+#, fuzzy
+msgid "Add: Spanish translation (@fitojb)"
+msgstr "Aggiunto: traduzione in danese (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:63
+#, fuzzy
+msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgstr "Aggiunto: traduzione in danese (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:70
+#: data/com.github.elfenware.badger.appdata.xml.in:93
 msgid "Update: Screenshot"
 msgstr "Aggiornamento: screenshot"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:37
-msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
+#: data/com.github.elfenware.badger.appdata.xml.in:77
+msgid "Add: New reminder for correcting your posture"
 msgstr ""
-"Aggiunto: 🎉️ interruttore globale per disabilitare tutti i promemoria 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:44
+#: data/com.github.elfenware.badger.appdata.xml.in:84
+msgid "Add: Checkboxes to toggle each timer (@andreasomaini)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:85
+msgid "Fix: Work correctly with the Notification Center (@nathanaelhoun)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:86
+msgid "Update: Improved icon"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:100
+msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
+msgstr "Aggiunto: 🎉️ interruttore globale per disabilitare tutti i promemoria 🎉️"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:107
 msgid "Add: Turkish translation (@libreajans)"
 msgstr "Aggiunto: traduzione in turco (@libreajans)."
 
-#: data/com.github.elfenware.badger.appdata.xml.in:51
+#: data/com.github.elfenware.badger.appdata.xml.in:114
 msgid "Add: Dutch translation (@Vistaus)"
 msgstr "Aggiunto: traduzione in olandese (@Vistaus)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:58
+#: data/com.github.elfenware.badger.appdata.xml.in:121
 msgid "Fix: \"Never\" option not disabling the timer"
 msgstr "Correzione: opzione \"Mai\" che non disabilita il timer"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:65
+#: data/com.github.elfenware.badger.appdata.xml.in:128
 msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr "Aggiunto: 🎉️ la funzione più attesa, timer personalizzati 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:66
+#: data/com.github.elfenware.badger.appdata.xml.in:129
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Aggiornato: traduzione in francese (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:67
+#: data/com.github.elfenware.badger.appdata.xml.in:130
 msgid "Update: Lithuanian translations (@welaq)"
 msgstr "Aggiornato: traduzione in lituano (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:68
+#: data/com.github.elfenware.badger.appdata.xml.in:131
 msgid "Update: Danish translations (@siigdev)"
 msgstr "Aggiornato: traduzione in danese (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:75
+#: data/com.github.elfenware.badger.appdata.xml.in:138
 msgid "Add: Danish translation (@siigdev)"
 msgstr "Aggiunto: traduzione in danese (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:76
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translation (@NathanBnm)"
 msgstr "Aggiornato: traduzione in francese (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:82
+#: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
 msgstr "Correzzione: finestra vuota all'avvio"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:87
+#: data/com.github.elfenware.badger.appdata.xml.in:150
 msgid "Add: Lithuanian translations (@welaq)"
 msgstr "Aggiunto: traduzione in lituano (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:88
+#: data/com.github.elfenware.badger.appdata.xml.in:151
 msgid "Fix: Illegible heading in dark mode"
 msgstr "Correzzione: titolo invisibile in modalità scura"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:93
+#: data/com.github.elfenware.badger.appdata.xml.in:156
 msgid "Add: French translations (@NathanBnm)"
 msgstr "Aggiunto: traduzione in francese (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:98
+#: data/com.github.elfenware.badger.appdata.xml.in:161
 msgid "Fix: Multiple notifications when window is opened &gt;1 times"
 msgstr ""
-"Correzzione: notifiche multiple quando la finestra viene aperta più di una volta"
+"Correzzione: notifiche multiple quando la finestra viene aperta più di una "
+"volta"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:103
+#: data/com.github.elfenware.badger.appdata.xml.in:166
 msgid "Fix: Remove manual line breaks from appdata"
 msgstr "Correzzione: rimozione delle interruzioni di riga manuali in appdata"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:108
+#: data/com.github.elfenware.badger.appdata.xml.in:171
 msgid "Fix: Use smaller window size by default"
 msgstr "Correzzione: la finestra è più piccola per impostazione predefinita"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:113
+#: data/com.github.elfenware.badger.appdata.xml.in:176
 msgid "Initial Release 🎉️"
 msgstr "Versione iniziale 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:149
+#: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-20 22:35+0530\n"
+"POT-Creation-Date: 2021-08-21 11:58+0200\n"
 "PO-Revision-Date: 2021-08-11 10:40-0200\n"
 "Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language-Team: Italian\n"
@@ -197,12 +197,12 @@ msgstr "Rimani in salute."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:31
 #, fuzzy
-msgid "Add: Czech translation (@pervoj)"
+msgid "Add: Czech translations (@pervoj)"
 msgstr "Aggiunto: traduzione in danese (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:32
 #, fuzzy
-msgid "Add: Italian translation (@albanobattistella)"
+msgid "Add: Italian translations (@albanobattistella)"
 msgstr "Aggiunto: traduzione in lituano (@welaq)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:38
@@ -216,17 +216,17 @@ msgid "Add: Dark style support"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:55
-msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgid "Add: Portuguese (Portugal) translations (@rottenpants466)"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:62
 #, fuzzy
-msgid "Add: Spanish translation (@fitojb)"
+msgid "Add: Spanish translations (@fitojb)"
 msgstr "Aggiunto: traduzione in danese (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
 #, fuzzy
-msgid "Add: Ukrainian translation (@IhorHordiichuk)"
+msgid "Add: Ukrainian translations (@IhorHordiichuk)"
 msgstr "Aggiunto: traduzione in danese (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70
@@ -255,11 +255,13 @@ msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
 msgstr "Aggiunto: 🎉️ interruttore globale per disabilitare tutti i promemoria 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:107
-msgid "Add: Turkish translation (@libreajans)"
+#, fuzzy
+msgid "Add: Turkish translations (@libreajans)"
 msgstr "Aggiunto: traduzione in turco (@libreajans)."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:114
-msgid "Add: Dutch translation (@Vistaus)"
+#, fuzzy
+msgid "Add: Dutch translations (@Vistaus)"
 msgstr "Aggiunto: traduzione in olandese (@Vistaus)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:121
@@ -271,6 +273,7 @@ msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr "Aggiunto: 🎉️ la funzione più attesa, timer personalizzati 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:129
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Aggiornato: traduzione in francese (@NathanBnm)"
 
@@ -283,12 +286,9 @@ msgid "Update: Danish translations (@siigdev)"
 msgstr "Aggiornato: traduzione in danese (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:138
-msgid "Add: Danish translation (@siigdev)"
+#, fuzzy
+msgid "Add: Danish translations (@siigdev)"
 msgstr "Aggiunto: traduzione in danese (@siigdev)"
-
-#: data/com.github.elfenware.badger.appdata.xml.in:139
-msgid "Update: French translation (@NathanBnm)"
-msgstr "Aggiornato: traduzione in francese (@NathanBnm)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
@@ -327,3 +327,6 @@ msgstr "Versione iniziale 🎉️"
 #: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"
+
+#~ msgid "Update: French translation (@NathanBnm)"
+#~ msgstr "Aggiornato: traduzione in francese (@NathanBnm)"

--- a/po/it.po
+++ b/po/it.po
@@ -226,7 +226,7 @@ msgstr "Aggiunto: traduzione in danese (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
 #, fuzzy
-msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgid "Add: Ukrainian translation (@IhorHordiichuk)"
 msgstr "Aggiunto: traduzione in danese (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70

--- a/po/lt.po
+++ b/po/lt.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-24 01:00+0530\n"
+"POT-Creation-Date: 2021-08-20 22:35+0530\n"
 "PO-Revision-Date: 2019-03-20 20:09+0200\n"
 "Last-Translator: Moo\n"
 "Language-Team: \n"
@@ -21,103 +21,103 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n"
 "%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/Application.vala:156
+#: src/Application.vala:164
 msgid "Blink your eyes"
 msgstr "Pamirksėkite"
 
-#: src/Application.vala:157
+#: src/Application.vala:165
 msgid "Look away from the screen and slowly blink your eyes for 10 seconds."
 msgstr "Atsisukite nuo ekrano ir lėtai 10 sekundžių pamirksėkite."
 
-#: src/Application.vala:158
+#: src/Application.vala:166
 msgid "Eyes:"
 msgstr "Akys:"
 
-#: src/Application.vala:163
+#: src/Application.vala:171
 msgid "Stretch your fingers"
 msgstr "Ištieskite pirštus"
 
-#: src/Application.vala:164
+#: src/Application.vala:172
 msgid "Spread out your palm wide, then close it into a fist. Repeat 5 times."
 msgstr ""
 "Išskleiskite delnus, o tuomet suspauskite kumščius. Pakartokite 5 kartus."
 
-#: src/Application.vala:165
+#: src/Application.vala:173
 msgid "Fingers:"
 msgstr "Pirštai:"
 
-#: src/Application.vala:170
+#: src/Application.vala:178
 msgid "Stretch your arms"
 msgstr "Ištieskite rankas"
 
-#: src/Application.vala:171
+#: src/Application.vala:179
 msgid "Stretch your arms, and twist your wrists for 10 seconds."
 msgstr "Ištieskite rankas ir 10 sekundžių pasukite riešus."
 
-#: src/Application.vala:172
+#: src/Application.vala:180
 msgid "Arms:"
 msgstr "Rankos:"
 
-#: src/Application.vala:177
+#: src/Application.vala:185
 msgid "Stretch your legs"
 msgstr "Ištieskite kojas"
 
-#: src/Application.vala:178
+#: src/Application.vala:186
 msgid "Stand up, twist each ankle, and bend each knee."
 msgstr "Atsistokite, pasukite kiekvieną kulkšnį ir sulenkite kiekvieną kelį."
 
-#: src/Application.vala:179
+#: src/Application.vala:187
 msgid "Legs:"
 msgstr "Kojos:"
 
-#: src/Application.vala:184
+#: src/Application.vala:192
 msgid "Turn your neck"
 msgstr "Pasukite kaklą"
 
-#: src/Application.vala:185
+#: src/Application.vala:193
 msgid "Turn your head in all directions. Repeat 3 times."
 msgstr "Pasukite galvą į kiekvieną pusę. Pakartokite 3 kartus."
 
-#: src/Application.vala:186
+#: src/Application.vala:194
 msgid "Neck:"
 msgstr "Kaklas:"
 
-#: src/Application.vala:191
+#: src/Application.vala:199
 msgid "Watch your posture"
 msgstr ""
 
-#: src/Application.vala:192
+#: src/Application.vala:200
 msgid "Make sure your back is straight."
 msgstr ""
 
-#: src/Application.vala:193
+#: src/Application.vala:201
 msgid "Posture:"
 msgstr ""
 
-#: src/MainGrid.vala:59
+#: src/MainGrid.vala:55
 msgid "Reminders"
 msgstr "Priminimai"
 
-#: src/MainGrid.vala:74
+#: src/MainGrid.vala:72
 msgid "Decide how often Badger should remind you to relax these:"
 msgstr ""
 "Nuspręskite kaip dažnai Badger turėtų jums priminti atpalaiduoti šias "
 "galūnes:"
 
-#: src/MainGrid.vala:114
+#: src/MainGrid.vala:115
 #, fuzzy
 msgid "1 min"
 msgstr "15 min."
 
-#: src/MainGrid.vala:116
+#: src/MainGrid.vala:117
 msgid "30 min"
 msgstr "30 min."
 
-#: src/MainGrid.vala:118
+#: src/MainGrid.vala:119
 msgid "1 hour"
 msgstr "1 val."
 
-#: src/MainGrid.vala:149
+#: src/MainGrid.vala:150
 #, c-format
 msgid "%.0f min"
 msgstr "%.0f min"
@@ -148,9 +148,9 @@ msgid "Remind yourself to not sit and stare at the screen for too long"
 msgstr "Priminkite sau nesedėti ilgai ir nespoksoti į ekraną"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:10
+#, fuzzy
 msgid ""
-"Whether you're dashing through Mario Kart on MupenGUI, binge-watching "
-"Silicon Valley on Cinema, or writing your next novel on Quilter, you need to "
+"When you are using your computer for extended periods of time, you need to "
 "relax your body every once in a while."
 msgstr ""
 "Nesvarbu, ar žaidžiate žaidimą naudodami MupenGUI, ar žiūrkite mėgstamą "
@@ -166,7 +166,8 @@ msgstr ""
 "leisti pailsėti savo akims ir raumenims."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:14
-msgid "Currently, it has these five reminders:"
+#, fuzzy
+msgid "Currently, it has these six reminders:"
 msgstr "Šiuo metu, programoje yra šie penki priminimai:"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:17
@@ -189,92 +190,147 @@ msgstr "Ištiesti kojas"
 msgid "Turn neck"
 msgstr "Pasukti kaklą"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:24
+#: data/com.github.elfenware.badger.appdata.xml.in:22
+msgid "Maintain posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:25
 msgid "Stay healthy."
 msgstr "Išlikite sveiki."
 
-#: data/com.github.elfenware.badger.appdata.xml.in:30
+#: data/com.github.elfenware.badger.appdata.xml.in:31
+#, fuzzy
+msgid "Add: Czech translation (@pervoj)"
+msgstr "Pridėta: Danų kalbos vertimas (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:32
+#, fuzzy
+msgid "Add: Italian translation (@albanobattistella)"
+msgstr "Pridėta: Lietuvių kalbos vertimas (@welaq)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:38
+#: data/com.github.elfenware.badger.appdata.xml.in:46
+msgid "Odin update 🎉️"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:40
+#: data/com.github.elfenware.badger.appdata.xml.in:48
+msgid "Add: Dark style support"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:55
+msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:62
+#, fuzzy
+msgid "Add: Spanish translation (@fitojb)"
+msgstr "Pridėta: Danų kalbos vertimas (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:63
+#, fuzzy
+msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgstr "Pridėta: Danų kalbos vertimas (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:70
+#: data/com.github.elfenware.badger.appdata.xml.in:93
 msgid "Update: Screenshot"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:37
+#: data/com.github.elfenware.badger.appdata.xml.in:77
+msgid "Add: New reminder for correcting your posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:84
+msgid "Add: Checkboxes to toggle each timer (@andreasomaini)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:85
+msgid "Fix: Work correctly with the Notification Center (@nathanaelhoun)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:86
+msgid "Update: Improved icon"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:100
 msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:44
+#: data/com.github.elfenware.badger.appdata.xml.in:107
 #, fuzzy
 msgid "Add: Turkish translation (@libreajans)"
 msgstr "Pridėta: Danų kalbos vertimas (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:51
+#: data/com.github.elfenware.badger.appdata.xml.in:114
 #, fuzzy
 msgid "Add: Dutch translation (@Vistaus)"
 msgstr "Pridėta: Danų kalbos vertimas (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:58
+#: data/com.github.elfenware.badger.appdata.xml.in:121
 msgid "Fix: \"Never\" option not disabling the timer"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:65
+#: data/com.github.elfenware.badger.appdata.xml.in:128
 msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr ""
 
-#: data/com.github.elfenware.badger.appdata.xml.in:66
+#: data/com.github.elfenware.badger.appdata.xml.in:129
 #, fuzzy
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Pridėta: Prancūzų kalbos vertimas (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:67
+#: data/com.github.elfenware.badger.appdata.xml.in:130
 #, fuzzy
 msgid "Update: Lithuanian translations (@welaq)"
 msgstr "Pridėta: Lietuvių kalbos vertimas (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:68
+#: data/com.github.elfenware.badger.appdata.xml.in:131
 #, fuzzy
 msgid "Update: Danish translations (@siigdev)"
 msgstr "Pridėta: Danų kalbos vertimas (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:75
+#: data/com.github.elfenware.badger.appdata.xml.in:138
 msgid "Add: Danish translation (@siigdev)"
 msgstr "Pridėta: Danų kalbos vertimas (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:76
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translation (@NathanBnm)"
 msgstr "Pridėta: Prancūzų kalbos vertimas (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:82
+#: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
 msgstr "Pataisa: Tuščias langas paleidimo metu"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:87
+#: data/com.github.elfenware.badger.appdata.xml.in:150
 msgid "Add: Lithuanian translations (@welaq)"
 msgstr "Pridėta: Lietuvių kalbos vertimas (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:88
+#: data/com.github.elfenware.badger.appdata.xml.in:151
 msgid "Fix: Illegible heading in dark mode"
 msgstr "Pataisa: Neįskaitoma antraštė tamsioje veiksenoje"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:93
+#: data/com.github.elfenware.badger.appdata.xml.in:156
 msgid "Add: French translations (@NathanBnm)"
 msgstr "Pridėta: Prancūzų kalbos vertimai (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:98
+#: data/com.github.elfenware.badger.appdata.xml.in:161
 msgid "Fix: Multiple notifications when window is opened &gt;1 times"
 msgstr "Pataisa: Keli pranešimai, kai langas yra atveriamas &gt;1 kartų"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:103
+#: data/com.github.elfenware.badger.appdata.xml.in:166
 msgid "Fix: Remove manual line breaks from appdata"
 msgstr "Pataisa: Pašalinta rankinė nauja eilutė iš programos duomenų"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:108
+#: data/com.github.elfenware.badger.appdata.xml.in:171
 msgid "Fix: Use smaller window size by default"
 msgstr "Pataisa: Pagal numatymą naudoti mažesnį lango dydį"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:113
+#: data/com.github.elfenware.badger.appdata.xml.in:176
 msgid "Initial Release 🎉️"
 msgstr "Pradinė laida 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:149
+#: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"
 

--- a/po/lt.po
+++ b/po/lt.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-20 22:35+0530\n"
+"POT-Creation-Date: 2021-08-21 11:58+0200\n"
 "PO-Revision-Date: 2019-03-20 20:09+0200\n"
 "Last-Translator: Moo\n"
 "Language-Team: \n"
@@ -200,12 +200,12 @@ msgstr "Išlikite sveiki."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:31
 #, fuzzy
-msgid "Add: Czech translation (@pervoj)"
+msgid "Add: Czech translations (@pervoj)"
 msgstr "Pridėta: Danų kalbos vertimas (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:32
 #, fuzzy
-msgid "Add: Italian translation (@albanobattistella)"
+msgid "Add: Italian translations (@albanobattistella)"
 msgstr "Pridėta: Lietuvių kalbos vertimas (@welaq)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:38
@@ -219,17 +219,17 @@ msgid "Add: Dark style support"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:55
-msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgid "Add: Portuguese (Portugal) translations (@rottenpants466)"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:62
 #, fuzzy
-msgid "Add: Spanish translation (@fitojb)"
+msgid "Add: Spanish translations (@fitojb)"
 msgstr "Pridėta: Danų kalbos vertimas (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
 #, fuzzy
-msgid "Add: Ukrainian translation (@IhorHordiichuk)"
+msgid "Add: Ukrainian translations (@IhorHordiichuk)"
 msgstr "Pridėta: Danų kalbos vertimas (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70
@@ -259,12 +259,12 @@ msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:107
 #, fuzzy
-msgid "Add: Turkish translation (@libreajans)"
+msgid "Add: Turkish translations (@libreajans)"
 msgstr "Pridėta: Danų kalbos vertimas (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:114
 #, fuzzy
-msgid "Add: Dutch translation (@Vistaus)"
+msgid "Add: Dutch translations (@Vistaus)"
 msgstr "Pridėta: Danų kalbos vertimas (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:121
@@ -276,6 +276,7 @@ msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:129
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 #, fuzzy
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Pridėta: Prancūzų kalbos vertimas (@NathanBnm)"
@@ -291,12 +292,9 @@ msgid "Update: Danish translations (@siigdev)"
 msgstr "Pridėta: Danų kalbos vertimas (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:138
-msgid "Add: Danish translation (@siigdev)"
+#, fuzzy
+msgid "Add: Danish translations (@siigdev)"
 msgstr "Pridėta: Danų kalbos vertimas (@siigdev)"
-
-#: data/com.github.elfenware.badger.appdata.xml.in:139
-msgid "Update: French translation (@NathanBnm)"
-msgstr "Pridėta: Prancūzų kalbos vertimas (@NathanBnm)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
@@ -333,6 +331,9 @@ msgstr "Pradinė laida 🎉️"
 #: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"
+
+#~ msgid "Update: French translation (@NathanBnm)"
+#~ msgstr "Pridėta: Prancūzų kalbos vertimas (@NathanBnm)"
 
 #~ msgid "Never"
 #~ msgstr "Niekada"

--- a/po/lt.po
+++ b/po/lt.po
@@ -229,7 +229,7 @@ msgstr "Pridėta: Danų kalbos vertimas (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
 #, fuzzy
-msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgid "Add: Ukrainian translation (@IhorHordiichuk)"
 msgstr "Pridėta: Danų kalbos vertimas (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70

--- a/po/nl.po
+++ b/po/nl.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-08-20 22:35+0530\n"
-"PO-Revision-Date: 2019-10-23 21:37+0200\n"
-"Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
+"PO-Revision-Date: 2021-08-20 20:37+0200\n"
+"Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <vistausss@outlook.com>\n"
 "Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.4\n"
+"X-Generator: Poedit 3.0\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: src/Application.vala:164
@@ -37,7 +37,7 @@ msgstr "Strek je vingers"
 
 #: src/Application.vala:172
 msgid "Spread out your palm wide, then close it into a fist. Repeat 5 times."
-msgstr "Spreid je vingers en maak daarna een vuist. Herhaal dit 5 keer."
+msgstr "Spreid je vingers en maak daarna een vuist en herhaal 5 keer."
 
 #: src/Application.vala:173
 msgid "Fingers:"
@@ -61,7 +61,7 @@ msgstr "Strek je benen"
 
 #: src/Application.vala:186
 msgid "Stand up, twist each ankle, and bend each knee."
-msgstr "Sta op, draai je enkels en buig je knieën één voor één."
+msgstr "Sta op, draai je enkels en buig één voor één je knieën."
 
 #: src/Application.vala:187
 msgid "Legs:"
@@ -73,7 +73,7 @@ msgstr "Draai je nek"
 
 #: src/Application.vala:193
 msgid "Turn your head in all directions. Repeat 3 times."
-msgstr "Draai je hoofd alle kanten op. Herhaal dit 3 keer."
+msgstr "Draai je hoofd alle kanten op en herhaal 3 keer."
 
 #: src/Application.vala:194
 msgid "Neck:"
@@ -85,7 +85,7 @@ msgstr "Let op je houding"
 
 #: src/Application.vala:200
 msgid "Make sure your back is straight."
-msgstr "Zorg ervoor dat je rug recht is."
+msgstr "Zorg er voor dat je rug recht is."
 
 #: src/Application.vala:201
 msgid "Posture:"
@@ -144,89 +144,82 @@ msgid "Remind yourself to not sit and stare at the screen for too long"
 msgstr "Herinner je eraan niet te lang naar het scherm te staren"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:10
-#, fuzzy
 msgid ""
 "When you are using your computer for extended periods of time, you need to "
 "relax your body every once in a while."
 msgstr ""
-"Of je jezelf nu een weg baant over de parcours van Mario Kart in MupenGUI, "
-"Silicon Valley on Cinema bingewatchet of je volgende boek schrijft in "
-"Quilter: je moet af en toe ontspannen."
+"Als je je computer langere tijd gebruikt, heeft je lichaam af en toe rust "
+"nodig."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:12
 msgid ""
 "Badger helps you do exactly that. It reminds you—or should I say, badgers you"
 "—to destress yourself and rest your eyes and muscles."
 msgstr ""
-"Badger helpt je daarbij. Badger stuurt je een herinnering om even wat rust "
-"te pakken, zowel voor je ogen als spieren."
+"Badger helpt je daarbij door je eraan te herinneren even wat rust te pakken, "
+"zowel voor je ogen als spieren."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:14
-#, fuzzy
 msgid "Currently, it has these six reminders:"
-msgstr "Momenteel heeft de app ondersteuning voor vijf herinneringen:"
+msgstr "Momenteel heeft de app ondersteuning voor zes herinneringen:"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:17
 msgid "Blink eyes"
-msgstr "Ogen knipperen"
+msgstr "Knipper met je ogen"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:18
 msgid "Stretch fingers"
-msgstr "Vingers strekken"
+msgstr "Strek je vingers"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:19
 msgid "Stretch arms"
-msgstr "Armen strekken"
+msgstr "Strek je armen"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:20
 msgid "Stretch legs"
-msgstr "Benen strekken"
+msgstr "Strek je benen"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:21
 msgid "Turn neck"
-msgstr "Nek draaien"
+msgstr "Draai je nek"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:22
 msgid "Maintain posture"
-msgstr ""
+msgstr "Zorg voor een goede houding"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:25
 msgid "Stay healthy."
 msgstr "Houd jezelf gezond."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:31
-#, fuzzy
 msgid "Add: Czech translation (@pervoj)"
-msgstr "Toegevoegd: Deense vertaling (@siigdev)"
+msgstr "[NIEUW] Tsjechische vertaling (met dank aan @pervoj)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:32
-#, fuzzy
 msgid "Add: Italian translation (@albanobattistella)"
-msgstr "Toegevoegd: Litouwse vertaling (@welaq)"
+msgstr "[NIEUW] Italiaanse vertaling (met dank aan @albanobattistella)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:38
 #: data/com.github.elfenware.badger.appdata.xml.in:46
 msgid "Odin update 🎉️"
-msgstr ""
+msgstr "Odin-update 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:40
 #: data/com.github.elfenware.badger.appdata.xml.in:48
 msgid "Add: Dark style support"
-msgstr ""
+msgstr "[NIEUW] Ondersteuning voor donkere thema's"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:55
 msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
-msgstr ""
+msgstr "[NIEUW] Portugese (Portugal) vertaling (met dank aan @rottenpants466)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:62
-#, fuzzy
 msgid "Add: Spanish translation (@fitojb)"
-msgstr "Toegevoegd: Deense vertaling (@siigdev)"
+msgstr "[NIEUW] Spaanse vertaling (met dank aan @fitojb)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
-#, fuzzy
 msgid "Add: Ukrainian translation (@IgorHordiichuk)"
-msgstr "Toegevoegd: Deense vertaling (@siigdev)"
+msgstr "[NIEUW] Oekraïense vertaling (met dank aan @IgorHordiichuk)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70
 #: data/com.github.elfenware.badger.appdata.xml.in:93
@@ -235,19 +228,23 @@ msgstr "Bijgewerkt: schermafdruk"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:77
 msgid "Add: New reminder for correcting your posture"
-msgstr ""
+msgstr "[NIEUW] Herinnering om een goede houding te behouden"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:84
 msgid "Add: Checkboxes to toggle each timer (@andreasomaini)"
 msgstr ""
+"[NIEUW] Aankruisvakjes om tijdklokken in en uit te schakelen (met dank aan "
+"@andreasomaini)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:85
 msgid "Fix: Work correctly with the Notification Center (@nathanaelhoun)"
 msgstr ""
+"[VERBETERD] Werkt nu goed samen met het meldingscentrum (met dank aan "
+"@nathanaeulhoun)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:86
 msgid "Update: Improved icon"
-msgstr ""
+msgstr "[BIJGEWERKT] Verbeterd pictogram"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:100
 msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"

--- a/po/nl.po
+++ b/po/nl.po
@@ -218,8 +218,8 @@ msgid "Add: Spanish translation (@fitojb)"
 msgstr "[NIEUW] Spaanse vertaling (met dank aan @fitojb)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
-msgid "Add: Ukrainian translation (@IgorHordiichuk)"
-msgstr "[NIEUW] Oekraïense vertaling (met dank aan @IgorHordiichuk)"
+msgid "Add: Ukrainian translation (@IhorHordiichuk)"
+msgstr "[NIEUW] Oekraïense vertaling (met dank aan @IhorHordiichuk)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70
 #: data/com.github.elfenware.badger.appdata.xml.in:93

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-20 22:35+0530\n"
+"POT-Creation-Date: 2021-08-21 11:58+0200\n"
 "PO-Revision-Date: 2021-08-20 20:37+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <vistausss@outlook.com>\n"
@@ -192,11 +192,13 @@ msgid "Stay healthy."
 msgstr "Houd jezelf gezond."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:31
-msgid "Add: Czech translation (@pervoj)"
+#, fuzzy
+msgid "Add: Czech translations (@pervoj)"
 msgstr "[NIEUW] Tsjechische vertaling (met dank aan @pervoj)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:32
-msgid "Add: Italian translation (@albanobattistella)"
+#, fuzzy
+msgid "Add: Italian translations (@albanobattistella)"
 msgstr "[NIEUW] Italiaanse vertaling (met dank aan @albanobattistella)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:38
@@ -210,15 +212,18 @@ msgid "Add: Dark style support"
 msgstr "[NIEUW] Ondersteuning voor donkere thema's"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:55
-msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+#, fuzzy
+msgid "Add: Portuguese (Portugal) translations (@rottenpants466)"
 msgstr "[NIEUW] Portugese (Portugal) vertaling (met dank aan @rottenpants466)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:62
-msgid "Add: Spanish translation (@fitojb)"
+#, fuzzy
+msgid "Add: Spanish translations (@fitojb)"
 msgstr "[NIEUW] Spaanse vertaling (met dank aan @fitojb)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
-msgid "Add: Ukrainian translation (@IhorHordiichuk)"
+#, fuzzy
+msgid "Add: Ukrainian translations (@IhorHordiichuk)"
 msgstr "[NIEUW] Oekraïense vertaling (met dank aan @IhorHordiichuk)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70
@@ -251,11 +256,13 @@ msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
 msgstr "Toegevoegd: 🎉️ optie om alle herinneringen uit te schakelen 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:107
-msgid "Add: Turkish translation (@libreajans)"
+#, fuzzy
+msgid "Add: Turkish translations (@libreajans)"
 msgstr "Toegevoegd: Turkse vertaling (@libreajans)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:114
-msgid "Add: Dutch translation (@Vistaus)"
+#, fuzzy
+msgid "Add: Dutch translations (@Vistaus)"
 msgstr "Toegevoegd: Nederlandse vertaling (@Vistaus)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:121
@@ -267,6 +274,7 @@ msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr "Toegevoegd: 🎉️ de meest-gewilde functie: aangepaste timers! 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:129
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Bijgewerkt: Franse vertaling (@NathanBnm)"
 
@@ -279,12 +287,9 @@ msgid "Update: Danish translations (@siigdev)"
 msgstr "Bijgewerkt: Deense vertaling (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:138
-msgid "Add: Danish translation (@siigdev)"
+#, fuzzy
+msgid "Add: Danish translations (@siigdev)"
 msgstr "Toegevoegd: Deense vertaling (@siigdev)"
-
-#: data/com.github.elfenware.badger.appdata.xml.in:139
-msgid "Update: French translation (@NathanBnm)"
-msgstr "Bijgewerkt: Franse vertaling (@NathanBnm)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
@@ -322,6 +327,9 @@ msgstr "Initiële uitgave 🎉️"
 #: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"
+
+#~ msgid "Update: French translation (@NathanBnm)"
+#~ msgstr "Bijgewerkt: Franse vertaling (@NathanBnm)"
 
 #~ msgid "Never"
 #~ msgstr "Nooit"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-24 01:00+0530\n"
+"POT-Creation-Date: 2021-08-20 22:35+0530\n"
 "PO-Revision-Date: 2019-10-23 21:37+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
 "Language-Team: Dutch <vistausss@outlook.com>\n"
@@ -18,102 +18,102 @@ msgstr ""
 "X-Generator: Poedit 2.2.4\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/Application.vala:156
+#: src/Application.vala:164
 msgid "Blink your eyes"
 msgstr "Knipper met je ogen"
 
-#: src/Application.vala:157
+#: src/Application.vala:165
 msgid "Look away from the screen and slowly blink your eyes for 10 seconds."
 msgstr ""
 "Kijk weg van het scherm en knipper langzaam met je ogen, 10 seconden lang."
 
-#: src/Application.vala:158
+#: src/Application.vala:166
 msgid "Eyes:"
 msgstr "Ogen:"
 
-#: src/Application.vala:163
+#: src/Application.vala:171
 msgid "Stretch your fingers"
 msgstr "Strek je vingers"
 
-#: src/Application.vala:164
+#: src/Application.vala:172
 msgid "Spread out your palm wide, then close it into a fist. Repeat 5 times."
 msgstr "Spreid je vingers en maak daarna een vuist. Herhaal dit 5 keer."
 
-#: src/Application.vala:165
+#: src/Application.vala:173
 msgid "Fingers:"
 msgstr "Vingers:"
 
-#: src/Application.vala:170
+#: src/Application.vala:178
 msgid "Stretch your arms"
 msgstr "Strek je armen"
 
-#: src/Application.vala:171
+#: src/Application.vala:179
 msgid "Stretch your arms, and twist your wrists for 10 seconds."
 msgstr "Strek je armen en draai je polsen, 10 seconden lang."
 
-#: src/Application.vala:172
+#: src/Application.vala:180
 msgid "Arms:"
 msgstr "Armen:"
 
-#: src/Application.vala:177
+#: src/Application.vala:185
 msgid "Stretch your legs"
 msgstr "Strek je benen"
 
-#: src/Application.vala:178
+#: src/Application.vala:186
 msgid "Stand up, twist each ankle, and bend each knee."
 msgstr "Sta op, draai je enkels en buig je knieën één voor één."
 
-#: src/Application.vala:179
+#: src/Application.vala:187
 msgid "Legs:"
 msgstr "Benen:"
 
-#: src/Application.vala:184
+#: src/Application.vala:192
 msgid "Turn your neck"
 msgstr "Draai je nek"
 
-#: src/Application.vala:185
+#: src/Application.vala:193
 msgid "Turn your head in all directions. Repeat 3 times."
 msgstr "Draai je hoofd alle kanten op. Herhaal dit 3 keer."
 
-#: src/Application.vala:186
+#: src/Application.vala:194
 msgid "Neck:"
 msgstr "Nek:"
 
-#: src/Application.vala:191
+#: src/Application.vala:199
 msgid "Watch your posture"
 msgstr "Let op je houding"
 
-#: src/Application.vala:192
+#: src/Application.vala:200
 msgid "Make sure your back is straight."
 msgstr "Zorg ervoor dat je rug recht is."
 
-#: src/Application.vala:193
+#: src/Application.vala:201
 msgid "Posture:"
 msgstr "Houding:"
 
-#: src/MainGrid.vala:59
+#: src/MainGrid.vala:55
 msgid "Reminders"
 msgstr "Herinneringen"
 
-#: src/MainGrid.vala:74
+#: src/MainGrid.vala:72
 msgid "Decide how often Badger should remind you to relax these:"
 msgstr ""
 "Hoe vaak Badger je eraan moet herinneren de volgende lichaamsdelen te "
 "ontspannen:"
 
-#: src/MainGrid.vala:114
+#: src/MainGrid.vala:115
 msgid "1 min"
 msgstr "1 min"
 
-#: src/MainGrid.vala:116
+#: src/MainGrid.vala:117
 msgid "30 min"
 msgstr "30 min"
 
-#: src/MainGrid.vala:118
+#: src/MainGrid.vala:119
 msgid "1 hour"
 msgstr "1 uur"
 
-#: src/MainGrid.vala:149
+#: src/MainGrid.vala:150
 #, c-format
 msgid "%.0f min"
 msgstr "%.0f min"
@@ -144,9 +144,9 @@ msgid "Remind yourself to not sit and stare at the screen for too long"
 msgstr "Herinner je eraan niet te lang naar het scherm te staren"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:10
+#, fuzzy
 msgid ""
-"Whether you're dashing through Mario Kart on MupenGUI, binge-watching "
-"Silicon Valley on Cinema, or writing your next novel on Quilter, you need to "
+"When you are using your computer for extended periods of time, you need to "
 "relax your body every once in a while."
 msgstr ""
 "Of je jezelf nu een weg baant over de parcours van Mario Kart in MupenGUI, "
@@ -162,7 +162,8 @@ msgstr ""
 "te pakken, zowel voor je ogen als spieren."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:14
-msgid "Currently, it has these five reminders:"
+#, fuzzy
+msgid "Currently, it has these six reminders:"
 msgstr "Momenteel heeft de app ondersteuning voor vijf herinneringen:"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:17
@@ -185,88 +186,143 @@ msgstr "Benen strekken"
 msgid "Turn neck"
 msgstr "Nek draaien"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:24
+#: data/com.github.elfenware.badger.appdata.xml.in:22
+msgid "Maintain posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:25
 msgid "Stay healthy."
 msgstr "Houd jezelf gezond."
 
-#: data/com.github.elfenware.badger.appdata.xml.in:30
+#: data/com.github.elfenware.badger.appdata.xml.in:31
+#, fuzzy
+msgid "Add: Czech translation (@pervoj)"
+msgstr "Toegevoegd: Deense vertaling (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:32
+#, fuzzy
+msgid "Add: Italian translation (@albanobattistella)"
+msgstr "Toegevoegd: Litouwse vertaling (@welaq)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:38
+#: data/com.github.elfenware.badger.appdata.xml.in:46
+msgid "Odin update 🎉️"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:40
+#: data/com.github.elfenware.badger.appdata.xml.in:48
+msgid "Add: Dark style support"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:55
+msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:62
+#, fuzzy
+msgid "Add: Spanish translation (@fitojb)"
+msgstr "Toegevoegd: Deense vertaling (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:63
+#, fuzzy
+msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgstr "Toegevoegd: Deense vertaling (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:70
+#: data/com.github.elfenware.badger.appdata.xml.in:93
 msgid "Update: Screenshot"
 msgstr "Bijgewerkt: schermafdruk"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:37
+#: data/com.github.elfenware.badger.appdata.xml.in:77
+msgid "Add: New reminder for correcting your posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:84
+msgid "Add: Checkboxes to toggle each timer (@andreasomaini)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:85
+msgid "Fix: Work correctly with the Notification Center (@nathanaelhoun)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:86
+msgid "Update: Improved icon"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:100
 msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
 msgstr "Toegevoegd: 🎉️ optie om alle herinneringen uit te schakelen 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:44
+#: data/com.github.elfenware.badger.appdata.xml.in:107
 msgid "Add: Turkish translation (@libreajans)"
 msgstr "Toegevoegd: Turkse vertaling (@libreajans)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:51
+#: data/com.github.elfenware.badger.appdata.xml.in:114
 msgid "Add: Dutch translation (@Vistaus)"
 msgstr "Toegevoegd: Nederlandse vertaling (@Vistaus)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:58
+#: data/com.github.elfenware.badger.appdata.xml.in:121
 msgid "Fix: \"Never\" option not disabling the timer"
 msgstr "Foutoplossing: 'nooit'-optie schakelde de timer niet uit"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:65
+#: data/com.github.elfenware.badger.appdata.xml.in:128
 msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr "Toegevoegd: 🎉️ de meest-gewilde functie: aangepaste timers! 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:66
+#: data/com.github.elfenware.badger.appdata.xml.in:129
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Bijgewerkt: Franse vertaling (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:67
+#: data/com.github.elfenware.badger.appdata.xml.in:130
 msgid "Update: Lithuanian translations (@welaq)"
 msgstr "Bijgewerkt: Litouwse vertaling (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:68
+#: data/com.github.elfenware.badger.appdata.xml.in:131
 msgid "Update: Danish translations (@siigdev)"
 msgstr "Bijgewerkt: Deense vertaling (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:75
+#: data/com.github.elfenware.badger.appdata.xml.in:138
 msgid "Add: Danish translation (@siigdev)"
 msgstr "Toegevoegd: Deense vertaling (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:76
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translation (@NathanBnm)"
 msgstr "Bijgewerkt: Franse vertaling (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:82
+#: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
 msgstr "Foutoplossing: leeg venster bij opstarten"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:87
+#: data/com.github.elfenware.badger.appdata.xml.in:150
 msgid "Add: Lithuanian translations (@welaq)"
 msgstr "Toegevoegd: Litouwse vertaling (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:88
+#: data/com.github.elfenware.badger.appdata.xml.in:151
 msgid "Fix: Illegible heading in dark mode"
 msgstr "Foutoplossing: onleesbare koptekst in donkere modus"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:93
+#: data/com.github.elfenware.badger.appdata.xml.in:156
 msgid "Add: French translations (@NathanBnm)"
 msgstr "Toegevoegd: Franse vertaling (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:98
+#: data/com.github.elfenware.badger.appdata.xml.in:161
 msgid "Fix: Multiple notifications when window is opened &gt;1 times"
 msgstr ""
 "Foutoplossing: meerdere meldingen als het venster &gt;1 keer geopend was"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:103
+#: data/com.github.elfenware.badger.appdata.xml.in:166
 msgid "Fix: Remove manual line breaks from appdata"
 msgstr "Foutoplossing: handmatige regeleindes verwijderd uit appdata"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:108
+#: data/com.github.elfenware.badger.appdata.xml.in:171
 msgid "Fix: Use smaller window size by default"
 msgstr "Foutoplossing: standaard is het scherm niet meer heel groot"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:113
+#: data/com.github.elfenware.badger.appdata.xml.in:176
 msgid "Initial Release 🎉️"
 msgstr "Initiële uitgave 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:149
+#: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -224,7 +224,7 @@ msgstr "Add: Danish translation (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
 #, fuzzy
-msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgid "Add: Ukrainian translation (@IhorHordiichuk)"
 msgstr "Add: Danish translation (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-04-18 00:27+0530\n"
+"POT-Creation-Date: 2021-08-20 22:35+0530\n"
 "PO-Revision-Date: 2020-02-29 23:20+0100\n"
 "Last-Translator: theszkut <theszkut@gmail.com>\n"
 "Language-Team: Polish <theszkut@gmail.com>\n"
@@ -17,95 +17,102 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/Application.vala:154
+#: src/Application.vala:164
 msgid "Blink your eyes"
 msgstr "Mrugaj"
 
-#: src/Application.vala:155
+#: src/Application.vala:165
 msgid "Look away from the screen and slowly blink your eyes for 10 seconds."
 msgstr "Popatrz poza ekran i mrugaj spokojnie przez 10 sekund."
 
-#: src/Application.vala:156
+#: src/Application.vala:166
 msgid "Eyes:"
 msgstr "Oczy:"
 
-#: src/Application.vala:161
+#: src/Application.vala:171
 msgid "Stretch your fingers"
 msgstr "Rozciągnij palce"
 
-#: src/Application.vala:162
+#: src/Application.vala:172
 msgid "Spread out your palm wide, then close it into a fist. Repeat 5 times."
-msgstr "Rozłóż szeroko palce u dłoni, a następnie zaciśnij je w pięść. Powtórz to 5 razy."
+msgstr ""
+"Rozłóż szeroko palce u dłoni, a następnie zaciśnij je w pięść. Powtórz to 5 "
+"razy."
 
-#: src/Application.vala:163
+#: src/Application.vala:173
 msgid "Fingers:"
 msgstr "Palce:"
 
-#: src/Application.vala:168
+#: src/Application.vala:178
 msgid "Stretch your arms"
 msgstr "Rozciągnij ręce"
 
-#: src/Application.vala:169
+#: src/Application.vala:179
 msgid "Stretch your arms, and twist your wrists for 10 seconds."
 msgstr "Rozciągnij ręce, oraz kręć nadgarstkami przez 10 sekund."
 
-#: src/Application.vala:170
+#: src/Application.vala:180
 msgid "Arms:"
 msgstr "Ręce:"
 
-#: src/Application.vala:175
+#: src/Application.vala:185
 msgid "Stretch your legs"
 msgstr "Rozciągnij nogi"
 
-#: src/Application.vala:176
+#: src/Application.vala:186
 msgid "Stand up, twist each ankle, and bend each knee."
 msgstr "Wstań, pokręć kostkami i zegnij oba kolana."
 
-#: src/Application.vala:177
+#: src/Application.vala:187
 msgid "Legs:"
 msgstr "Nogi:"
 
-#: src/Application.vala:182
+#: src/Application.vala:192
 msgid "Turn your neck"
 msgstr "Rusz szyją"
 
-#: src/Application.vala:183
+#: src/Application.vala:193
 msgid "Turn your head in all directions. Repeat 3 times."
 msgstr "Obróc głowę w każdą stronę. Powtórz 3 razy."
 
-#: src/Application.vala:184
+#: src/Application.vala:194
 msgid "Neck:"
 msgstr "Szyja:"
 
-#: src/MainGrid.vala:57
+#: src/Application.vala:199
+msgid "Watch your posture"
+msgstr ""
+
+#: src/Application.vala:200
+msgid "Make sure your back is straight."
+msgstr ""
+
+#: src/Application.vala:201
+msgid "Posture:"
+msgstr ""
+
+#: src/MainGrid.vala:55
 msgid "Reminders"
 msgstr "Przypomnienia"
 
-#: src/MainGrid.vala:62
+#: src/MainGrid.vala:72
 msgid "Decide how often Badger should remind you to relax these:"
 msgstr "Zdecyduj jak często Badger powinien przypominać o przerwach:"
 
-#: src/MainGrid.vala:85 src/MainGrid.vala:107
-msgid "Never"
-msgstr "Nigdy"
-
-#: src/MainGrid.vala:86
-msgid "15 min"
+#: src/MainGrid.vala:115
+#, fuzzy
+msgid "1 min"
 msgstr "15 min"
 
-#: src/MainGrid.vala:87
+#: src/MainGrid.vala:117
 msgid "30 min"
 msgstr "30 min"
 
-#: src/MainGrid.vala:88
-msgid "45 min"
-msgstr "45 min"
-
-#: src/MainGrid.vala:89
+#: src/MainGrid.vala:119
 msgid "1 hour"
 msgstr "1 godzina"
 
-#: src/MainGrid.vala:110
+#: src/MainGrid.vala:150
 #, c-format
 msgid "%.0f min"
 msgstr "%.0f min"
@@ -136,14 +143,14 @@ msgid "Remind yourself to not sit and stare at the screen for too long"
 msgstr "Pamiętaj, aby nie siedzieć i patrzeć w ekran zbyt dłgugo"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:10
+#, fuzzy
 msgid ""
-"Whether you're dashing through Mario Kart on MupenGUI, binge-watching "
-"Silicon Valley on Cinema, or writing your next novel on Quilter, you need to "
+"When you are using your computer for extended periods of time, you need to "
 "relax your body every once in a while."
 msgstr ""
-"Za każdym razem, gdy pędzisz w swoim Mario Karcie w MupenGUI, urządzasz maraton "
-"Silicon Valley na Cinema lub piszesz swoją kolejną powieść w Quilter, powinieneś "
-"raz na jakiś czas odprężyć swoje ciało."
+"Za każdym razem, gdy pędzisz w swoim Mario Karcie w MupenGUI, urządzasz "
+"maraton Silicon Valley na Cinema lub piszesz swoją kolejną powieść w "
+"Quilter, powinieneś raz na jakiś czas odprężyć swoje ciało."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:12
 msgid ""
@@ -154,7 +161,8 @@ msgstr ""
 "aby przypomnieć Ci o chwili rozluźnienia dla Twoich oczu i mięśni."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:14
-msgid "Currently, it has these five reminders:"
+#, fuzzy
+msgid "Currently, it has these six reminders:"
 msgstr "Obecnie posiada pięć przypomnień:"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:17
@@ -177,50 +185,152 @@ msgstr "Rozciągnij nogi"
 msgid "Turn neck"
 msgstr "Rusz szyją"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:24
+#: data/com.github.elfenware.badger.appdata.xml.in:22
+msgid "Maintain posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:25
 msgid "Stay healthy."
 msgstr "Zostań zdrowy."
 
-#: data/com.github.elfenware.badger.appdata.xml.in:30
+#: data/com.github.elfenware.badger.appdata.xml.in:31
+#, fuzzy
+msgid "Add: Czech translation (@pervoj)"
+msgstr "Add: Danish translation (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:32
+#, fuzzy
+msgid "Add: Italian translation (@albanobattistella)"
+msgstr "Add: Lithuanian translations (@welaq)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:38
+#: data/com.github.elfenware.badger.appdata.xml.in:46
+msgid "Odin update 🎉️"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:40
+#: data/com.github.elfenware.badger.appdata.xml.in:48
+msgid "Add: Dark style support"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:55
+msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:62
+#, fuzzy
+msgid "Add: Spanish translation (@fitojb)"
+msgstr "Add: Danish translation (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:63
+#, fuzzy
+msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgstr "Add: Danish translation (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:70
+#: data/com.github.elfenware.badger.appdata.xml.in:93
+msgid "Update: Screenshot"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:77
+msgid "Add: New reminder for correcting your posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:84
+msgid "Add: Checkboxes to toggle each timer (@andreasomaini)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:85
+msgid "Fix: Work correctly with the Notification Center (@nathanaelhoun)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:86
+msgid "Update: Improved icon"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:100
+msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:107
+#, fuzzy
+msgid "Add: Turkish translation (@libreajans)"
+msgstr "Add: Danish translation (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:114
+#, fuzzy
+msgid "Add: Dutch translation (@Vistaus)"
+msgstr "Add: Danish translation (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:121
+msgid "Fix: \"Never\" option not disabling the timer"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:128
+msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:129
+#, fuzzy
+msgid "Update: French translations (@NathanBnm)"
+msgstr "Update: French translation (@NathanBnm)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:130
+#, fuzzy
+msgid "Update: Lithuanian translations (@welaq)"
+msgstr "Add: Lithuanian translations (@welaq)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:131
+#, fuzzy
+msgid "Update: Danish translations (@siigdev)"
+msgstr "Add: Danish translation (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:138
 msgid "Add: Danish translation (@siigdev)"
 msgstr "Add: Danish translation (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:31
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translation (@NathanBnm)"
 msgstr "Update: French translation (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:37
+#: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
 msgstr "Fix: Empty window on launch"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:42
+#: data/com.github.elfenware.badger.appdata.xml.in:150
 msgid "Add: Lithuanian translations (@welaq)"
 msgstr "Add: Lithuanian translations (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:43
+#: data/com.github.elfenware.badger.appdata.xml.in:151
 msgid "Fix: Illegible heading in dark mode"
 msgstr "Fix: Illegible heading in dark mode"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:48
+#: data/com.github.elfenware.badger.appdata.xml.in:156
 msgid "Add: French translations (@NathanBnm)"
 msgstr "Add: French translations (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:53
+#: data/com.github.elfenware.badger.appdata.xml.in:161
 msgid "Fix: Multiple notifications when window is opened &gt;1 times"
 msgstr "Fix: Multiple notifications when window is opened &gt;1 times"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:58
+#: data/com.github.elfenware.badger.appdata.xml.in:166
 msgid "Fix: Remove manual line breaks from appdata"
 msgstr "Fix: Remove manual line breaks from appdata"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:63
+#: data/com.github.elfenware.badger.appdata.xml.in:171
 msgid "Fix: Use smaller window size by default"
 msgstr "Fix: Use smaller window size by default"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:68
+#: data/com.github.elfenware.badger.appdata.xml.in:176
 msgid "Initial Release 🎉️"
 msgstr "Initial Release 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:104
+#: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"
+
+#~ msgid "Never"
+#~ msgstr "Nigdy"
+
+#~ msgid "45 min"
+#~ msgstr "45 min"

--- a/po/pl.po
+++ b/po/pl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-20 22:35+0530\n"
+"POT-Creation-Date: 2021-08-21 11:58+0200\n"
 "PO-Revision-Date: 2020-02-29 23:20+0100\n"
 "Last-Translator: theszkut <theszkut@gmail.com>\n"
 "Language-Team: Polish <theszkut@gmail.com>\n"
@@ -195,12 +195,12 @@ msgstr "Zostań zdrowy."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:31
 #, fuzzy
-msgid "Add: Czech translation (@pervoj)"
+msgid "Add: Czech translations (@pervoj)"
 msgstr "Add: Danish translation (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:32
 #, fuzzy
-msgid "Add: Italian translation (@albanobattistella)"
+msgid "Add: Italian translations (@albanobattistella)"
 msgstr "Add: Lithuanian translations (@welaq)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:38
@@ -214,17 +214,17 @@ msgid "Add: Dark style support"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:55
-msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgid "Add: Portuguese (Portugal) translations (@rottenpants466)"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:62
 #, fuzzy
-msgid "Add: Spanish translation (@fitojb)"
+msgid "Add: Spanish translations (@fitojb)"
 msgstr "Add: Danish translation (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
 #, fuzzy
-msgid "Add: Ukrainian translation (@IhorHordiichuk)"
+msgid "Add: Ukrainian translations (@IhorHordiichuk)"
 msgstr "Add: Danish translation (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70
@@ -254,12 +254,12 @@ msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:107
 #, fuzzy
-msgid "Add: Turkish translation (@libreajans)"
+msgid "Add: Turkish translations (@libreajans)"
 msgstr "Add: Danish translation (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:114
 #, fuzzy
-msgid "Add: Dutch translation (@Vistaus)"
+msgid "Add: Dutch translations (@Vistaus)"
 msgstr "Add: Danish translation (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:121
@@ -271,6 +271,7 @@ msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:129
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 #, fuzzy
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Update: French translation (@NathanBnm)"
@@ -286,12 +287,9 @@ msgid "Update: Danish translations (@siigdev)"
 msgstr "Add: Danish translation (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:138
-msgid "Add: Danish translation (@siigdev)"
+#, fuzzy
+msgid "Add: Danish translations (@siigdev)"
 msgstr "Add: Danish translation (@siigdev)"
-
-#: data/com.github.elfenware.badger.appdata.xml.in:139
-msgid "Update: French translation (@NathanBnm)"
-msgstr "Update: French translation (@NathanBnm)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
@@ -328,6 +326,9 @@ msgstr "Initial Release 🎉️"
 #: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"
+
+#~ msgid "Update: French translation (@NathanBnm)"
+#~ msgstr "Update: French translation (@NathanBnm)"
 
 #~ msgid "Never"
 #~ msgstr "Nigdy"

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,113 +7,113 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-24 01:00+0530\n"
+"POT-Creation-Date: 2021-08-20 22:35+0530\n"
 "PO-Revision-Date: 2020-08-18 00:43+0100\n"
+"Last-Translator: André Barata <andretiagob@protonmail.com\n"
 "Language-Team: Portuguese (Portugal)\n"
+"Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.4.1\n"
-"Last-Translator: André Barata <andretiagob@protonmail.com\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: pt\n"
 
-#: src/Application.vala:156
+#: src/Application.vala:164
 msgid "Blink your eyes"
 msgstr "Pestaneje os seus olhos"
 
-#: src/Application.vala:157
+#: src/Application.vala:165
 msgid "Look away from the screen and slowly blink your eyes for 10 seconds."
 msgstr ""
 "Desvie o olhar do ecrã e pestaneje lentamente os seus olhos durante 10 "
 "segundos."
 
-#: src/Application.vala:158
+#: src/Application.vala:166
 msgid "Eyes:"
 msgstr "Olhos:"
 
-#: src/Application.vala:163
+#: src/Application.vala:171
 msgid "Stretch your fingers"
 msgstr "Estique os seus dedos"
 
-#: src/Application.vala:164
+#: src/Application.vala:172
 msgid "Spread out your palm wide, then close it into a fist. Repeat 5 times."
 msgstr ""
 "Abra bem a palma da sua mão, a seguir feche-a em punho. Repita 5 vezes."
 
-#: src/Application.vala:165
+#: src/Application.vala:173
 msgid "Fingers:"
 msgstr "Dedos:"
 
-#: src/Application.vala:170
+#: src/Application.vala:178
 msgid "Stretch your arms"
 msgstr "Estique os seus braços"
 
-#: src/Application.vala:171
+#: src/Application.vala:179
 msgid "Stretch your arms, and twist your wrists for 10 seconds."
 msgstr "Estique os seus braços, e torça os seus pulsos durante 10 segundos."
 
-#: src/Application.vala:172
+#: src/Application.vala:180
 msgid "Arms:"
 msgstr "Braços:"
 
-#: src/Application.vala:177
+#: src/Application.vala:185
 msgid "Stretch your legs"
 msgstr "Estique as suas pernas"
 
-#: src/Application.vala:178
+#: src/Application.vala:186
 msgid "Stand up, twist each ankle, and bend each knee."
 msgstr "Levante-se, torça cada tornozelo, e dobre cada joelho."
 
-#: src/Application.vala:179
+#: src/Application.vala:187
 msgid "Legs:"
 msgstr "Pernas:"
 
-#: src/Application.vala:184
+#: src/Application.vala:192
 msgid "Turn your neck"
 msgstr "Vire o seu pescoço"
 
-#: src/Application.vala:185
+#: src/Application.vala:193
 msgid "Turn your head in all directions. Repeat 3 times."
 msgstr "Vire a sua cabeça em todas as direções. Repita 3 vezes."
 
-#: src/Application.vala:186
+#: src/Application.vala:194
 msgid "Neck:"
 msgstr "Pescoço:"
 
-#: src/Application.vala:191
+#: src/Application.vala:199
 msgid "Watch your posture"
 msgstr "Veja a sua postura"
 
-#: src/Application.vala:192
+#: src/Application.vala:200
 msgid "Make sure your back is straight."
 msgstr "Certifique-se que tem as costas direitas."
 
-#: src/Application.vala:193
+#: src/Application.vala:201
 msgid "Posture:"
 msgstr "Postura:"
 
-#: src/MainGrid.vala:59
+#: src/MainGrid.vala:55
 msgid "Reminders"
 msgstr "Lembretes"
 
-#: src/MainGrid.vala:74
+#: src/MainGrid.vala:72
 msgid "Decide how often Badger should remind you to relax these:"
 msgstr "Decida com que frequência o Badger o deve lembrar para relaxar:"
 
-#: src/MainGrid.vala:114
+#: src/MainGrid.vala:115
 msgid "1 min"
 msgstr "1 min"
 
-#: src/MainGrid.vala:116
+#: src/MainGrid.vala:117
 msgid "30 min"
 msgstr "30 min"
 
-#: src/MainGrid.vala:118
+#: src/MainGrid.vala:119
 msgid "1 hour"
 msgstr "1 hora"
 
-#: src/MainGrid.vala:149
+#: src/MainGrid.vala:150
 #, c-format
 msgid "%.0f min"
 msgstr "%.0f min"
@@ -146,9 +146,9 @@ msgstr ""
 "muito tempo"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:10
+#, fuzzy
 msgid ""
-"Whether you're dashing through Mario Kart on MupenGUI, binge-watching "
-"Silicon Valley on Cinema, or writing your next novel on Quilter, you need to "
+"When you are using your computer for extended periods of time, you need to "
 "relax your body every once in a while."
 msgstr ""
 "Se você estiver a correr no Mario Kart no MupenGUI, a ter uma maratona de "
@@ -164,7 +164,8 @@ msgstr ""
 "chateia-o—para se relaxar e descansar os seus olhos e músculos."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:14
-msgid "Currently, it has these five reminders:"
+#, fuzzy
+msgid "Currently, it has these six reminders:"
 msgstr "De momento, ele tem estes cinco lembretes:"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:17
@@ -187,87 +188,142 @@ msgstr "Esticar pernas"
 msgid "Turn neck"
 msgstr "Virar pescoço"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:24
+#: data/com.github.elfenware.badger.appdata.xml.in:22
+msgid "Maintain posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:25
 msgid "Stay healthy."
 msgstr "Manter-se saudável."
 
-#: data/com.github.elfenware.badger.appdata.xml.in:30
+#: data/com.github.elfenware.badger.appdata.xml.in:31
+#, fuzzy
+msgid "Add: Czech translation (@pervoj)"
+msgstr "Adicionado: Tradução Dinamarquesa (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:32
+#, fuzzy
+msgid "Add: Italian translation (@albanobattistella)"
+msgstr "Adicionado: Tradução Lituana (@welaq)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:38
+#: data/com.github.elfenware.badger.appdata.xml.in:46
+msgid "Odin update 🎉️"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:40
+#: data/com.github.elfenware.badger.appdata.xml.in:48
+msgid "Add: Dark style support"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:55
+msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:62
+#, fuzzy
+msgid "Add: Spanish translation (@fitojb)"
+msgstr "Adicionado: Tradução Dinamarquesa (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:63
+#, fuzzy
+msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgstr "Adicionado: Tradução Dinamarquesa (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:70
+#: data/com.github.elfenware.badger.appdata.xml.in:93
 msgid "Update: Screenshot"
 msgstr "Atualização: Disparo de Ecrã"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:37
+#: data/com.github.elfenware.badger.appdata.xml.in:77
+msgid "Add: New reminder for correcting your posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:84
+msgid "Add: Checkboxes to toggle each timer (@andreasomaini)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:85
+msgid "Fix: Work correctly with the Notification Center (@nathanaelhoun)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:86
+msgid "Update: Improved icon"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:100
 msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
 msgstr "Adicionado: 🎉️ Interruptor global para desligar todos os lembretes 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:44
+#: data/com.github.elfenware.badger.appdata.xml.in:107
 msgid "Add: Turkish translation (@libreajans)"
 msgstr "Adicionado: Tradução Turca (@libreajans)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:51
+#: data/com.github.elfenware.badger.appdata.xml.in:114
 msgid "Add: Dutch translation (@Vistaus)"
 msgstr "Adicionado: Tradução Holandesa (@Vistaus)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:58
+#: data/com.github.elfenware.badger.appdata.xml.in:121
 msgid "Fix: \"Never\" option not disabling the timer"
 msgstr "Corrigido: Opção \"Nunca\" não desativar o temporizador"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:65
+#: data/com.github.elfenware.badger.appdata.xml.in:128
 msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr ""
 "Adicionado: 🎉️ Funcionalidade mais esperada, temporizadores personalizados! 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:66
+#: data/com.github.elfenware.badger.appdata.xml.in:129
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Atualizado: Tradução Francesa (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:67
+#: data/com.github.elfenware.badger.appdata.xml.in:130
 msgid "Update: Lithuanian translations (@welaq)"
 msgstr "Atualizado: Tradução Lituana (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:68
+#: data/com.github.elfenware.badger.appdata.xml.in:131
 msgid "Update: Danish translations (@siigdev)"
 msgstr "Atualizado: Tradução Dinamarquesa (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:75
+#: data/com.github.elfenware.badger.appdata.xml.in:138
 msgid "Add: Danish translation (@siigdev)"
 msgstr "Adicionado: Tradução Dinamarquesa (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:76
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translation (@NathanBnm)"
 msgstr "Atualizado: Tradução Francesa (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:82
+#: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
 msgstr "Corrigido: Janela vazia ao iniciar"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:87
+#: data/com.github.elfenware.badger.appdata.xml.in:150
 msgid "Add: Lithuanian translations (@welaq)"
 msgstr "Adicionado: Tradução Lituana (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:88
+#: data/com.github.elfenware.badger.appdata.xml.in:151
 msgid "Fix: Illegible heading in dark mode"
 msgstr "Corrigido: Título ilegível no modo escuro"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:93
+#: data/com.github.elfenware.badger.appdata.xml.in:156
 msgid "Add: French translations (@NathanBnm)"
 msgstr "Adicionado: Tradução Francesa (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:98
+#: data/com.github.elfenware.badger.appdata.xml.in:161
 msgid "Fix: Multiple notifications when window is opened &gt;1 times"
 msgstr "Corrigido: Múltiplas notificações quando a janela é aberta &gt; 1 vez"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:103
+#: data/com.github.elfenware.badger.appdata.xml.in:166
 msgid "Fix: Remove manual line breaks from appdata"
 msgstr "Corrigido: Quebras de linha manuais removidas da appdata"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:108
+#: data/com.github.elfenware.badger.appdata.xml.in:171
 msgid "Fix: Use smaller window size by default"
 msgstr "Corrigido: Usar o tamanho pequeno da janela por defeito"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:113
+#: data/com.github.elfenware.badger.appdata.xml.in:176
 msgid "Initial Release 🎉️"
 msgstr "Lançamento inicial 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:149
+#: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"

--- a/po/pt.po
+++ b/po/pt.po
@@ -227,7 +227,7 @@ msgstr "Adicionado: Tradução Dinamarquesa (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
 #, fuzzy
-msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgid "Add: Ukrainian translation (@IhorHordiichuk)"
 msgstr "Adicionado: Tradução Dinamarquesa (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-20 22:35+0530\n"
+"POT-Creation-Date: 2021-08-21 11:58+0200\n"
 "PO-Revision-Date: 2020-08-18 00:43+0100\n"
 "Last-Translator: André Barata <andretiagob@protonmail.com\n"
 "Language-Team: Portuguese (Portugal)\n"
@@ -198,12 +198,12 @@ msgstr "Manter-se saudável."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:31
 #, fuzzy
-msgid "Add: Czech translation (@pervoj)"
+msgid "Add: Czech translations (@pervoj)"
 msgstr "Adicionado: Tradução Dinamarquesa (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:32
 #, fuzzy
-msgid "Add: Italian translation (@albanobattistella)"
+msgid "Add: Italian translations (@albanobattistella)"
 msgstr "Adicionado: Tradução Lituana (@welaq)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:38
@@ -217,17 +217,17 @@ msgid "Add: Dark style support"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:55
-msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgid "Add: Portuguese (Portugal) translations (@rottenpants466)"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:62
 #, fuzzy
-msgid "Add: Spanish translation (@fitojb)"
+msgid "Add: Spanish translations (@fitojb)"
 msgstr "Adicionado: Tradução Dinamarquesa (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
 #, fuzzy
-msgid "Add: Ukrainian translation (@IhorHordiichuk)"
+msgid "Add: Ukrainian translations (@IhorHordiichuk)"
 msgstr "Adicionado: Tradução Dinamarquesa (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70
@@ -256,11 +256,13 @@ msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
 msgstr "Adicionado: 🎉️ Interruptor global para desligar todos os lembretes 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:107
-msgid "Add: Turkish translation (@libreajans)"
+#, fuzzy
+msgid "Add: Turkish translations (@libreajans)"
 msgstr "Adicionado: Tradução Turca (@libreajans)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:114
-msgid "Add: Dutch translation (@Vistaus)"
+#, fuzzy
+msgid "Add: Dutch translations (@Vistaus)"
 msgstr "Adicionado: Tradução Holandesa (@Vistaus)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:121
@@ -273,6 +275,7 @@ msgstr ""
 "Adicionado: 🎉️ Funcionalidade mais esperada, temporizadores personalizados! 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:129
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Atualizado: Tradução Francesa (@NathanBnm)"
 
@@ -285,12 +288,9 @@ msgid "Update: Danish translations (@siigdev)"
 msgstr "Atualizado: Tradução Dinamarquesa (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:138
-msgid "Add: Danish translation (@siigdev)"
+#, fuzzy
+msgid "Add: Danish translations (@siigdev)"
 msgstr "Adicionado: Tradução Dinamarquesa (@siigdev)"
-
-#: data/com.github.elfenware.badger.appdata.xml.in:139
-msgid "Update: French translation (@NathanBnm)"
-msgstr "Atualizado: Tradução Francesa (@NathanBnm)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
@@ -327,3 +327,6 @@ msgstr "Lançamento inicial 🎉️"
 #: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"
+
+#~ msgid "Update: French translation (@NathanBnm)"
+#~ msgstr "Atualizado: Tradução Francesa (@NathanBnm)"

--- a/po/tr.po
+++ b/po/tr.po
@@ -239,7 +239,7 @@ msgstr "Eklendi: Danca çeviri (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
 #, fuzzy
-msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgid "Add: Ukrainian translation (@IhorHordiichuk)"
 msgstr "Eklendi: Danca çeviri (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70

--- a/po/tr.po
+++ b/po/tr.po
@@ -15,8 +15,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
-"Report-Msgid-Bugs-To: https://github.com/elfenware/badger/issues\n"
-"POT-Creation-Date: 2019-10-24 01:00+0530\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-08-20 22:35+0530\n"
 "PO-Revision-Date: 2019-10-23 22:39+0300\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: \n"
@@ -27,101 +27,101 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: src/Application.vala:156
+#: src/Application.vala:164
 msgid "Blink your eyes"
 msgstr "Gözlerini kırp"
 
-#: src/Application.vala:157
+#: src/Application.vala:165
 msgid "Look away from the screen and slowly blink your eyes for 10 seconds."
 msgstr "Ekrandan uzağa bak ve 10 saniye boyunca yavaşça gözlerini kırp."
 
-#: src/Application.vala:158
+#: src/Application.vala:166
 msgid "Eyes:"
 msgstr "Gözler:"
 
-#: src/Application.vala:163
+#: src/Application.vala:171
 msgid "Stretch your fingers"
 msgstr "Parmaklarını esnet"
 
-#: src/Application.vala:164
+#: src/Application.vala:172
 msgid "Spread out your palm wide, then close it into a fist. Repeat 5 times."
 msgstr "Avucunu genişçe aç, sonrasında yumruk yapıp kapat. 5 kez tekrarla."
 
-#: src/Application.vala:165
+#: src/Application.vala:173
 msgid "Fingers:"
 msgstr "Parmaklar:"
 
-#: src/Application.vala:170
+#: src/Application.vala:178
 msgid "Stretch your arms"
 msgstr "Kollarını esnet"
 
-#: src/Application.vala:171
+#: src/Application.vala:179
 msgid "Stretch your arms, and twist your wrists for 10 seconds."
 msgstr "Kollarını esnet ve bileklerini 10 saniye boyunca döndür."
 
-#: src/Application.vala:172
+#: src/Application.vala:180
 msgid "Arms:"
 msgstr "Kollar:"
 
-#: src/Application.vala:177
+#: src/Application.vala:185
 msgid "Stretch your legs"
 msgstr "Bacaklarını esnet"
 
-#: src/Application.vala:178
+#: src/Application.vala:186
 msgid "Stand up, twist each ankle, and bend each knee."
 msgstr "Ayağa kalk, her bir bileğini ve her bir dizini bük."
 
-#: src/Application.vala:179
+#: src/Application.vala:187
 msgid "Legs:"
 msgstr "Bacaklar:"
 
-#: src/Application.vala:184
+#: src/Application.vala:192
 msgid "Turn your neck"
 msgstr "Boynunu çevir"
 
-#: src/Application.vala:185
+#: src/Application.vala:193
 msgid "Turn your head in all directions. Repeat 3 times."
 msgstr "Başını her yöne çevir. 3 kez tekrarla."
 
-#: src/Application.vala:186
+#: src/Application.vala:194
 msgid "Neck:"
 msgstr "Boyun:"
 
-#: src/Application.vala:191
+#: src/Application.vala:199
 msgid "Watch your posture"
 msgstr "Duruşunu izle"
 
-#: src/Application.vala:192
+#: src/Application.vala:200
 msgid "Make sure your back is straight."
 msgstr "Sırtının düz olduğundan emin ol."
 
-#: src/Application.vala:193
+#: src/Application.vala:201
 msgid "Posture:"
 msgstr "Duruş:"
 
-#: src/MainGrid.vala:59
+#: src/MainGrid.vala:55
 msgid "Reminders"
 msgstr "Hatırlatıcı"
 
-#: src/MainGrid.vala:74
+#: src/MainGrid.vala:72
 msgid "Decide how often Badger should remind you to relax these:"
 msgstr ""
 "Badger'ın size ne sıklıkta rahatlamanız gerektiğini hatırlatması gerektiğine "
 "karar verin:"
 
-#: src/MainGrid.vala:114
+#: src/MainGrid.vala:115
 msgid "1 min"
 msgstr "1 dak"
 
-#: src/MainGrid.vala:116
+#: src/MainGrid.vala:117
 msgid "30 min"
 msgstr "30 dak"
 
-#: src/MainGrid.vala:118
+#: src/MainGrid.vala:119
 msgid "1 hour"
 msgstr "1 saat"
 
-#: src/MainGrid.vala:149
+#: src/MainGrid.vala:150
 #, c-format
 msgid "%.0f min"
 msgstr "%.0f dak"
@@ -157,9 +157,9 @@ msgstr ""
 
 # Türkiyeyle uyumlu serbest çeviri yapılmıştır. Özgünü taklide çalışmayın.
 #: data/com.github.elfenware.badger.appdata.xml.in:10
+#, fuzzy
 msgid ""
-"Whether you're dashing through Mario Kart on MupenGUI, binge-watching "
-"Silicon Valley on Cinema, or writing your next novel on Quilter, you need to "
+"When you are using your computer for extended periods of time, you need to "
 "relax your body every once in a while."
 msgstr ""
 "İster bilgisayar başında oyun oynuyor olun, ister film izliyor veya gelecek "
@@ -176,7 +176,8 @@ msgstr ""
 "kaslarınızı ve gözlerinizi dinlendirmenizi hatırlatır."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:14
-msgid "Currently, it has these five reminders:"
+#, fuzzy
+msgid "Currently, it has these six reminders:"
 msgstr "Şu anda, şu beş hatırlatıcı var:"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:17
@@ -199,89 +200,144 @@ msgstr "Bacaklarını esnet"
 msgid "Turn neck"
 msgstr "Boynunu çevir"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:24
+#: data/com.github.elfenware.badger.appdata.xml.in:22
+msgid "Maintain posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:25
 msgid "Stay healthy."
 msgstr "Sağlıklı kal."
 
-#: data/com.github.elfenware.badger.appdata.xml.in:30
+#: data/com.github.elfenware.badger.appdata.xml.in:31
+#, fuzzy
+msgid "Add: Czech translation (@pervoj)"
+msgstr "Eklendi: Danca çeviri (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:32
+#, fuzzy
+msgid "Add: Italian translation (@albanobattistella)"
+msgstr "Eklendi: Litvanca çeviri (@welaq)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:38
+#: data/com.github.elfenware.badger.appdata.xml.in:46
+msgid "Odin update 🎉️"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:40
+#: data/com.github.elfenware.badger.appdata.xml.in:48
+msgid "Add: Dark style support"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:55
+msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:62
+#, fuzzy
+msgid "Add: Spanish translation (@fitojb)"
+msgstr "Eklendi: Danca çeviri (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:63
+#, fuzzy
+msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgstr "Eklendi: Danca çeviri (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:70
+#: data/com.github.elfenware.badger.appdata.xml.in:93
 msgid "Update: Screenshot"
 msgstr "Güncellendi: Ekran görüntüsü"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:37
+#: data/com.github.elfenware.badger.appdata.xml.in:77
+msgid "Add: New reminder for correcting your posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:84
+msgid "Add: Checkboxes to toggle each timer (@andreasomaini)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:85
+msgid "Fix: Work correctly with the Notification Center (@nathanaelhoun)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:86
+msgid "Update: Improved icon"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:100
 msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
 msgstr "Eklendi: 🎉️ Tüm hatırlatıcıları kapatmak için genel anahtar 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:44
+#: data/com.github.elfenware.badger.appdata.xml.in:107
 msgid "Add: Turkish translation (@libreajans)"
 msgstr "Eklendi: Türkçe çeviri (@libreajans)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:51
+#: data/com.github.elfenware.badger.appdata.xml.in:114
 msgid "Add: Dutch translation (@Vistaus)"
 msgstr "Eklendi: Flemenkçe çeviri (@Vistaus)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:58
+#: data/com.github.elfenware.badger.appdata.xml.in:121
 msgid "Fix: \"Never\" option not disabling the timer"
 msgstr "Düzeltildi: \"Asla\" seçeneği zamanlayıcıyı devre dışı bırakmıyor"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:65
+#: data/com.github.elfenware.badger.appdata.xml.in:128
 msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr "Eklendi: 🎉️ En çok beklenen özellik, özel zamanlayıcı! 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:66
+#: data/com.github.elfenware.badger.appdata.xml.in:129
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Güncellendi: Fransızca çeviri (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:67
+#: data/com.github.elfenware.badger.appdata.xml.in:130
 msgid "Update: Lithuanian translations (@welaq)"
 msgstr "Güncellendi: Litvanca çeviri (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:68
+#: data/com.github.elfenware.badger.appdata.xml.in:131
 msgid "Update: Danish translations (@siigdev)"
 msgstr "Güncellendi: Danca çeviri (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:75
+#: data/com.github.elfenware.badger.appdata.xml.in:138
 msgid "Add: Danish translation (@siigdev)"
 msgstr "Eklendi: Danca çeviri (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:76
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translation (@NathanBnm)"
 msgstr "Güncellendi: Fransızca çeviri (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:82
+#: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
 msgstr "Düzeltme: Başlangıçta boş pencere"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:87
+#: data/com.github.elfenware.badger.appdata.xml.in:150
 msgid "Add: Lithuanian translations (@welaq)"
 msgstr "Eklendi: Litvanca çeviri (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:88
+#: data/com.github.elfenware.badger.appdata.xml.in:151
 msgid "Fix: Illegible heading in dark mode"
 msgstr "Düzeltme: Koyu kipde geçersiz başlık"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:93
+#: data/com.github.elfenware.badger.appdata.xml.in:156
 msgid "Add: French translations (@NathanBnm)"
 msgstr "Eklendi: Fransızca çeviri (@NathanBnm)"
 
 # &gt;1 kısmı birden çok defa olarak çevrildi
-#: data/com.github.elfenware.badger.appdata.xml.in:98
+#: data/com.github.elfenware.badger.appdata.xml.in:161
 msgid "Fix: Multiple notifications when window is opened &gt;1 times"
 msgstr "Düzeltme: Pencere birden çok defa açıldığında çoklu uyarı"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:103
+#: data/com.github.elfenware.badger.appdata.xml.in:166
 msgid "Fix: Remove manual line breaks from appdata"
 msgstr ""
 "Düzeltme: El ile girilmiş satır sonlarını appdata dosyasından kaldırıldı"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:108
+#: data/com.github.elfenware.badger.appdata.xml.in:171
 msgid "Fix: Use smaller window size by default"
 msgstr "Düzeltme: Öntanımlı olarak daha küçük pencere boyutu kullan"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:113
+#: data/com.github.elfenware.badger.appdata.xml.in:176
 msgid "Initial Release 🎉️"
 msgstr "İlk Sürüm 🎉️"
 
 # Yazılım geliştiren oluşumun adı, çevirmeyin.
-#: data/com.github.elfenware.badger.appdata.xml.in:149
+#: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"

--- a/po/tr.po
+++ b/po/tr.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-20 22:35+0530\n"
+"POT-Creation-Date: 2021-08-21 11:58+0200\n"
 "PO-Revision-Date: 2019-10-23 22:39+0300\n"
 "Last-Translator: Sabri Ünal <libreajans@gmail.com>\n"
 "Language-Team: \n"
@@ -210,12 +210,12 @@ msgstr "Sağlıklı kal."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:31
 #, fuzzy
-msgid "Add: Czech translation (@pervoj)"
+msgid "Add: Czech translations (@pervoj)"
 msgstr "Eklendi: Danca çeviri (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:32
 #, fuzzy
-msgid "Add: Italian translation (@albanobattistella)"
+msgid "Add: Italian translations (@albanobattistella)"
 msgstr "Eklendi: Litvanca çeviri (@welaq)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:38
@@ -229,17 +229,17 @@ msgid "Add: Dark style support"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:55
-msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgid "Add: Portuguese (Portugal) translations (@rottenpants466)"
 msgstr ""
 
 #: data/com.github.elfenware.badger.appdata.xml.in:62
 #, fuzzy
-msgid "Add: Spanish translation (@fitojb)"
+msgid "Add: Spanish translations (@fitojb)"
 msgstr "Eklendi: Danca çeviri (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
 #, fuzzy
-msgid "Add: Ukrainian translation (@IhorHordiichuk)"
+msgid "Add: Ukrainian translations (@IhorHordiichuk)"
 msgstr "Eklendi: Danca çeviri (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70
@@ -268,11 +268,13 @@ msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
 msgstr "Eklendi: 🎉️ Tüm hatırlatıcıları kapatmak için genel anahtar 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:107
-msgid "Add: Turkish translation (@libreajans)"
+#, fuzzy
+msgid "Add: Turkish translations (@libreajans)"
 msgstr "Eklendi: Türkçe çeviri (@libreajans)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:114
-msgid "Add: Dutch translation (@Vistaus)"
+#, fuzzy
+msgid "Add: Dutch translations (@Vistaus)"
 msgstr "Eklendi: Flemenkçe çeviri (@Vistaus)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:121
@@ -284,6 +286,7 @@ msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr "Eklendi: 🎉️ En çok beklenen özellik, özel zamanlayıcı! 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:129
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Güncellendi: Fransızca çeviri (@NathanBnm)"
 
@@ -296,12 +299,9 @@ msgid "Update: Danish translations (@siigdev)"
 msgstr "Güncellendi: Danca çeviri (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:138
-msgid "Add: Danish translation (@siigdev)"
+#, fuzzy
+msgid "Add: Danish translations (@siigdev)"
 msgstr "Eklendi: Danca çeviri (@siigdev)"
-
-#: data/com.github.elfenware.badger.appdata.xml.in:139
-msgid "Update: French translation (@NathanBnm)"
-msgstr "Güncellendi: Fransızca çeviri (@NathanBnm)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
@@ -341,3 +341,6 @@ msgstr "İlk Sürüm 🎉️"
 #: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"
+
+#~ msgid "Update: French translation (@NathanBnm)"
+#~ msgstr "Güncellendi: Fransızca çeviri (@NathanBnm)"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-08-20 22:35+0530\n"
-"PO-Revision-Date: 2020-05-22 03:46+0300\n"
+"PO-Revision-Date: 2021-08-21 02:50+0300\n"
 "Last-Translator: Ihor Hordiichuk <igor_ck@outlook.com>\n"
 "Language-Team: \n"
 "Language: uk\n"
@@ -17,6 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"X-Generator: Poedit 3.0\n"
 
 #: src/Application.vala:164
 msgid "Blink your eyes"
@@ -143,27 +144,24 @@ msgid "Remind yourself to not sit and stare at the screen for too long"
 msgstr "Нагадайте собі не сидіти та не дивитися на екран занадто довго"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:10
-#, fuzzy
 msgid ""
 "When you are using your computer for extended periods of time, you need to "
 "relax your body every once in a while."
 msgstr ""
-"Незалежно від того, чи ви жваво граєте у Mario Kart на MupenGUI, чи спокійно "
-"переглядаєте Кремнієву долину в кіно, чи пишете наступний роман на Quilter, "
-"вам необхідно час від часу розслабляти ваше тіло."
+"Якщо ви працюєте за комп'ютер впродовж тривалого часу, варто час від часу "
+"розминати тіло."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:12
 msgid ""
 "Badger helps you do exactly that. It reminds you—or should I say, badgers you"
 "—to destress yourself and rest your eyes and muscles."
 msgstr ""
-"Badger допомагає зробити саме це. Він нагадує вам — чи то пак, змушує вас — "
-"відволіктися та розслабити ваші очі та м'язи."
+"Badger допомагає зробити саме це. Він нагадує вам, чи то пак, змушує вас "
+"зняти напруження та розслабити ваші очі та м'язи."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:14
-#, fuzzy
 msgid "Currently, it has these six reminders:"
-msgstr "Наразі, наявні п'ять нагадувань:"
+msgstr "Наразі, доступні шість нагадувань:"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:17
 msgid "Blink eyes"
@@ -187,45 +185,41 @@ msgstr "Покрутити шиєю"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:22
 msgid "Maintain posture"
-msgstr ""
+msgstr "Контроль постави"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:25
 msgid "Stay healthy."
 msgstr "Будьте здорові."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:31
-#, fuzzy
 msgid "Add: Czech translation (@pervoj)"
-msgstr "Додано: переклад данською (@siigdev)"
+msgstr "Додано: Переклад чеською (@pervoj)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:32
-#, fuzzy
 msgid "Add: Italian translation (@albanobattistella)"
-msgstr "Додано: переклад литовською (@welaq)"
+msgstr "Додано: Переклад італійською (@albanobattistella)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:38
 #: data/com.github.elfenware.badger.appdata.xml.in:46
 msgid "Odin update 🎉️"
-msgstr ""
+msgstr "Оновлено для Odin 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:40
 #: data/com.github.elfenware.badger.appdata.xml.in:48
 msgid "Add: Dark style support"
-msgstr ""
+msgstr "Додано: Підтримку темного стилю"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:55
 msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
-msgstr ""
+msgstr "Додано: Переклад португальською (Португалія) (@rottenpants466)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:62
-#, fuzzy
 msgid "Add: Spanish translation (@fitojb)"
-msgstr "Додано: переклад данською (@siigdev)"
+msgstr "Додано: Переклад іспанською (@fitojb)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
-#, fuzzy
 msgid "Add: Ukrainian translation (@IgorHordiichuk)"
-msgstr "Додано: переклад данською (@siigdev)"
+msgstr "Додано: Переклад українською (@IgorHordiichuk)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70
 #: data/com.github.elfenware.badger.appdata.xml.in:93
@@ -234,19 +228,19 @@ msgstr "Оновлено: Знімки екрана"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:77
 msgid "Add: New reminder for correcting your posture"
-msgstr ""
+msgstr "Додано: Нове нагадування для виправлення постави"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:84
 msgid "Add: Checkboxes to toggle each timer (@andreasomaini)"
-msgstr ""
+msgstr "Додано: Прапорці для перемикання кожного таймера (@andreasomaini)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:85
 msgid "Fix: Work correctly with the Notification Center (@nathanaelhoun)"
-msgstr ""
+msgstr "Виправлення: Виправлено роботу з Центром сповіщень (@nathanaelhoun)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:86
 msgid "Update: Improved icon"
-msgstr ""
+msgstr "Оновлення: Вдосконалено піктограму"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:100
 msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"

--- a/po/uk.po
+++ b/po/uk.po
@@ -218,8 +218,8 @@ msgid "Add: Spanish translation (@fitojb)"
 msgstr "Додано: Переклад іспанською (@fitojb)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
-msgid "Add: Ukrainian translation (@IgorHordiichuk)"
-msgstr "Додано: Переклад українською (@IgorHordiichuk)"
+msgid "Add: Ukrainian translation (@IhorHordiichuk)"
+msgstr "Додано: Переклад українською (@IhorHordiichuk)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70
 #: data/com.github.elfenware.badger.appdata.xml.in:93

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-20 22:35+0530\n"
+"POT-Creation-Date: 2021-08-21 11:58+0200\n"
 "PO-Revision-Date: 2021-08-21 02:50+0300\n"
 "Last-Translator: Ihor Hordiichuk <igor_ck@outlook.com>\n"
 "Language-Team: \n"
@@ -192,11 +192,13 @@ msgid "Stay healthy."
 msgstr "Будьте здорові."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:31
-msgid "Add: Czech translation (@pervoj)"
+#, fuzzy
+msgid "Add: Czech translations (@pervoj)"
 msgstr "Додано: Переклад чеською (@pervoj)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:32
-msgid "Add: Italian translation (@albanobattistella)"
+#, fuzzy
+msgid "Add: Italian translations (@albanobattistella)"
 msgstr "Додано: Переклад італійською (@albanobattistella)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:38
@@ -210,15 +212,18 @@ msgid "Add: Dark style support"
 msgstr "Додано: Підтримку темного стилю"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:55
-msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+#, fuzzy
+msgid "Add: Portuguese (Portugal) translations (@rottenpants466)"
 msgstr "Додано: Переклад португальською (Португалія) (@rottenpants466)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:62
-msgid "Add: Spanish translation (@fitojb)"
+#, fuzzy
+msgid "Add: Spanish translations (@fitojb)"
 msgstr "Додано: Переклад іспанською (@fitojb)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:63
-msgid "Add: Ukrainian translation (@IhorHordiichuk)"
+#, fuzzy
+msgid "Add: Ukrainian translations (@IhorHordiichuk)"
 msgstr "Додано: Переклад українською (@IhorHordiichuk)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:70
@@ -247,11 +252,13 @@ msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
 msgstr "Додано: 🎉️ Загальний вимикач усіх нагадувань 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:107
-msgid "Add: Turkish translation (@libreajans)"
+#, fuzzy
+msgid "Add: Turkish translations (@libreajans)"
 msgstr "Додано: переклад турецькою (@libreajans)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:114
-msgid "Add: Dutch translation (@Vistaus)"
+#, fuzzy
+msgid "Add: Dutch translations (@Vistaus)"
 msgstr "Додано: переклад нідерландською (@Vistaus)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:121
@@ -263,6 +270,7 @@ msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr "Додано: 🎉️ Найочікуванішу функцію — налаштування таймерів! 🎉️"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:129
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Оновлено: переклад французькою (@NathanBnm)"
 
@@ -275,12 +283,9 @@ msgid "Update: Danish translations (@siigdev)"
 msgstr "Оновлено: переклад данською (@siigdev)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:138
-msgid "Add: Danish translation (@siigdev)"
+#, fuzzy
+msgid "Add: Danish translations (@siigdev)"
 msgstr "Додано: переклад данською (@siigdev)"
-
-#: data/com.github.elfenware.badger.appdata.xml.in:139
-msgid "Update: French translation (@NathanBnm)"
-msgstr "Оновлено: переклад французькою (@NathanBnm)"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
@@ -318,3 +323,6 @@ msgstr "Початковий випуск 🎉️"
 #: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"
+
+#~ msgid "Update: French translation (@NathanBnm)"
+#~ msgstr "Оновлено: переклад французькою (@NathanBnm)"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.badger\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-24 01:00+0530\n"
+"POT-Creation-Date: 2021-08-20 22:35+0530\n"
 "PO-Revision-Date: 2020-05-22 03:46+0300\n"
 "Last-Translator: Ihor Hordiichuk <igor_ck@outlook.com>\n"
 "Language-Team: \n"
@@ -18,100 +18,100 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
-#: src/Application.vala:156
+#: src/Application.vala:164
 msgid "Blink your eyes"
 msgstr "Покліпайте очима"
 
-#: src/Application.vala:157
+#: src/Application.vala:165
 msgid "Look away from the screen and slowly blink your eyes for 10 seconds."
 msgstr ""
 "Відведіть погляд від екрана та повільно кліпайте очима впродовж 10 секунд."
 
-#: src/Application.vala:158
+#: src/Application.vala:166
 msgid "Eyes:"
 msgstr "Очі:"
 
-#: src/Application.vala:163
+#: src/Application.vala:171
 msgid "Stretch your fingers"
 msgstr "Порозминайте пальці"
 
-#: src/Application.vala:164
+#: src/Application.vala:172
 msgid "Spread out your palm wide, then close it into a fist. Repeat 5 times."
 msgstr "Широко розкрийте долоню, потім стисніть її в кулак. Повторіть 5 разів."
 
-#: src/Application.vala:165
+#: src/Application.vala:173
 msgid "Fingers:"
 msgstr "Пальці:"
 
-#: src/Application.vala:170
+#: src/Application.vala:178
 msgid "Stretch your arms"
 msgstr "Порозминайте руки"
 
-#: src/Application.vala:171
+#: src/Application.vala:179
 msgid "Stretch your arms, and twist your wrists for 10 seconds."
 msgstr "Розпрямте руки та покрутіть зап'ястя впродовж 10 секунд."
 
-#: src/Application.vala:172
+#: src/Application.vala:180
 msgid "Arms:"
 msgstr "Руки:"
 
-#: src/Application.vala:177
+#: src/Application.vala:185
 msgid "Stretch your legs"
 msgstr "Порозминайте ноги"
 
-#: src/Application.vala:178
+#: src/Application.vala:186
 msgid "Stand up, twist each ankle, and bend each knee."
 msgstr "Встаньте, покрутіть кожною щиколоткою, позгинайте ноги в колінах."
 
-#: src/Application.vala:179
+#: src/Application.vala:187
 msgid "Legs:"
 msgstr "Ноги:"
 
-#: src/Application.vala:184
+#: src/Application.vala:192
 msgid "Turn your neck"
 msgstr "Покрутіть шиєю"
 
-#: src/Application.vala:185
+#: src/Application.vala:193
 msgid "Turn your head in all directions. Repeat 3 times."
 msgstr "Покрутіть головою в усі боки. Повторіть 3 рази."
 
-#: src/Application.vala:186
+#: src/Application.vala:194
 msgid "Neck:"
 msgstr "Шия:"
 
-#: src/Application.vala:191
+#: src/Application.vala:199
 msgid "Watch your posture"
 msgstr "Слідкуйте за поставою"
 
-#: src/Application.vala:192
+#: src/Application.vala:200
 msgid "Make sure your back is straight."
 msgstr "Переконайтеся, що ваша спина випростана."
 
-#: src/Application.vala:193
+#: src/Application.vala:201
 msgid "Posture:"
 msgstr "Постава:"
 
-#: src/MainGrid.vala:59
+#: src/MainGrid.vala:55
 msgid "Reminders"
 msgstr "Нагадування"
 
-#: src/MainGrid.vala:74
+#: src/MainGrid.vala:72
 msgid "Decide how often Badger should remind you to relax these:"
 msgstr "Визначте, як часто Badger повинен нагадувати вам розслабити:"
 
-#: src/MainGrid.vala:114
+#: src/MainGrid.vala:115
 msgid "1 min"
 msgstr "1 хвилина"
 
-#: src/MainGrid.vala:116
+#: src/MainGrid.vala:117
 msgid "30 min"
 msgstr "30 хвилин"
 
-#: src/MainGrid.vala:118
+#: src/MainGrid.vala:119
 msgid "1 hour"
 msgstr "1 година"
 
-#: src/MainGrid.vala:149
+#: src/MainGrid.vala:150
 #, c-format
 msgid "%.0f min"
 msgstr "%.0f хв"
@@ -135,16 +135,17 @@ msgstr "com.github.elfenware.badger"
 
 #: data/com.github.elfenware.badger.desktop.in:11
 msgid "Ergonomics;Health;Eyes;Muscles;"
-msgstr "Ergonomics;Health;Eyes;Muscles;Зручність;Здоровʼя;Очі;Мʼязи;Відпочинок;"
+msgstr ""
+"Ergonomics;Health;Eyes;Muscles;Зручність;Здоровʼя;Очі;Мʼязи;Відпочинок;"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:8
 msgid "Remind yourself to not sit and stare at the screen for too long"
 msgstr "Нагадайте собі не сидіти та не дивитися на екран занадто довго"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:10
+#, fuzzy
 msgid ""
-"Whether you're dashing through Mario Kart on MupenGUI, binge-watching "
-"Silicon Valley on Cinema, or writing your next novel on Quilter, you need to "
+"When you are using your computer for extended periods of time, you need to "
 "relax your body every once in a while."
 msgstr ""
 "Незалежно від того, чи ви жваво граєте у Mario Kart на MupenGUI, чи спокійно "
@@ -160,7 +161,8 @@ msgstr ""
 "відволіктися та розслабити ваші очі та м'язи."
 
 #: data/com.github.elfenware.badger.appdata.xml.in:14
-msgid "Currently, it has these five reminders:"
+#, fuzzy
+msgid "Currently, it has these six reminders:"
 msgstr "Наразі, наявні п'ять нагадувань:"
 
 #: data/com.github.elfenware.badger.appdata.xml.in:17
@@ -183,87 +185,142 @@ msgstr "Порозминати ноги"
 msgid "Turn neck"
 msgstr "Покрутити шиєю"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:24
+#: data/com.github.elfenware.badger.appdata.xml.in:22
+msgid "Maintain posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:25
 msgid "Stay healthy."
 msgstr "Будьте здорові."
 
-#: data/com.github.elfenware.badger.appdata.xml.in:30
+#: data/com.github.elfenware.badger.appdata.xml.in:31
+#, fuzzy
+msgid "Add: Czech translation (@pervoj)"
+msgstr "Додано: переклад данською (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:32
+#, fuzzy
+msgid "Add: Italian translation (@albanobattistella)"
+msgstr "Додано: переклад литовською (@welaq)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:38
+#: data/com.github.elfenware.badger.appdata.xml.in:46
+msgid "Odin update 🎉️"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:40
+#: data/com.github.elfenware.badger.appdata.xml.in:48
+msgid "Add: Dark style support"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:55
+msgid "Add: Portuguese (Portugal) translation (@rottenpants466)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:62
+#, fuzzy
+msgid "Add: Spanish translation (@fitojb)"
+msgstr "Додано: переклад данською (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:63
+#, fuzzy
+msgid "Add: Ukrainian translation (@IgorHordiichuk)"
+msgstr "Додано: переклад данською (@siigdev)"
+
+#: data/com.github.elfenware.badger.appdata.xml.in:70
+#: data/com.github.elfenware.badger.appdata.xml.in:93
 msgid "Update: Screenshot"
 msgstr "Оновлено: Знімки екрана"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:37
+#: data/com.github.elfenware.badger.appdata.xml.in:77
+msgid "Add: New reminder for correcting your posture"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:84
+msgid "Add: Checkboxes to toggle each timer (@andreasomaini)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:85
+msgid "Fix: Work correctly with the Notification Center (@nathanaelhoun)"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:86
+msgid "Update: Improved icon"
+msgstr ""
+
+#: data/com.github.elfenware.badger.appdata.xml.in:100
 msgid "Add: 🎉️ Global switch to turn off all reminders 🎉️"
 msgstr "Додано: 🎉️ Загальний вимикач усіх нагадувань 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:44
+#: data/com.github.elfenware.badger.appdata.xml.in:107
 msgid "Add: Turkish translation (@libreajans)"
 msgstr "Додано: переклад турецькою (@libreajans)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:51
+#: data/com.github.elfenware.badger.appdata.xml.in:114
 msgid "Add: Dutch translation (@Vistaus)"
 msgstr "Додано: переклад нідерландською (@Vistaus)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:58
+#: data/com.github.elfenware.badger.appdata.xml.in:121
 msgid "Fix: \"Never\" option not disabling the timer"
 msgstr "Виправлено: параметр \"Ніколи\" не вимикає таймер"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:65
+#: data/com.github.elfenware.badger.appdata.xml.in:128
 msgid "Add: 🎉️ Most awaited feature, custom timers! 🎉️"
 msgstr "Додано: 🎉️ Найочікуванішу функцію — налаштування таймерів! 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:66
+#: data/com.github.elfenware.badger.appdata.xml.in:129
 msgid "Update: French translations (@NathanBnm)"
 msgstr "Оновлено: переклад французькою (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:67
+#: data/com.github.elfenware.badger.appdata.xml.in:130
 msgid "Update: Lithuanian translations (@welaq)"
 msgstr "Оновлено: переклад литовською (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:68
+#: data/com.github.elfenware.badger.appdata.xml.in:131
 msgid "Update: Danish translations (@siigdev)"
 msgstr "Оновлено: переклад данською (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:75
+#: data/com.github.elfenware.badger.appdata.xml.in:138
 msgid "Add: Danish translation (@siigdev)"
 msgstr "Додано: переклад данською (@siigdev)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:76
+#: data/com.github.elfenware.badger.appdata.xml.in:139
 msgid "Update: French translation (@NathanBnm)"
 msgstr "Оновлено: переклад французькою (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:82
+#: data/com.github.elfenware.badger.appdata.xml.in:145
 msgid "Fix: Empty window on launch"
 msgstr "Виправлено: запуск вікна порожнім"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:87
+#: data/com.github.elfenware.badger.appdata.xml.in:150
 msgid "Add: Lithuanian translations (@welaq)"
 msgstr "Додано: переклад литовською (@welaq)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:88
+#: data/com.github.elfenware.badger.appdata.xml.in:151
 msgid "Fix: Illegible heading in dark mode"
 msgstr "Виправлено: нерозбірливий заголовок у темному режимі"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:93
+#: data/com.github.elfenware.badger.appdata.xml.in:156
 msgid "Add: French translations (@NathanBnm)"
 msgstr "Додано: переклад французькою (@NathanBnm)"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:98
+#: data/com.github.elfenware.badger.appdata.xml.in:161
 msgid "Fix: Multiple notifications when window is opened &gt;1 times"
 msgstr ""
 "Виправлено: появу кількох сповіщень під час відкриття вікна &gt;1 разів"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:103
+#: data/com.github.elfenware.badger.appdata.xml.in:166
 msgid "Fix: Remove manual line breaks from appdata"
 msgstr "Виправлено: вилучено розриви рядків з appdata, доданих вручну"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:108
+#: data/com.github.elfenware.badger.appdata.xml.in:171
 msgid "Fix: Use smaller window size by default"
 msgstr "Виправлено: зменшено типовий розмір вікна"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:113
+#: data/com.github.elfenware.badger.appdata.xml.in:176
 msgid "Initial Release 🎉️"
 msgstr "Початковий випуск 🎉️"
 
-#: data/com.github.elfenware.badger.appdata.xml.in:149
+#: data/com.github.elfenware.badger.appdata.xml.in:212
 msgid "Elfenware"
 msgstr "Elfenware"


### PR DESCRIPTION
This PR cleans up the app description, mainly removing the references to three apps (MupenGUI, Cinema, Quilter) which are either not actively maintained or have switched platforms. Moreover, the references to Silicon Valley and Mario Kart might not even be culturally sensible everywhere.

It also mentions the posture reminder in the app description, and contains the release notes for a couple of new versions built for elementary OS 6.0 Odin.