### PR TITLE
Fix translations not being loaded in the sandbox

### DIFF
--- a/config.vala.in
+++ b/config.vala.in
@@ -1,5 +1,6 @@
 namespace Constants {
     public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+    public const string LOCALEDIR = @LOCALEDIR@;
     public const string PROJECT_NAME = @PROJECT_NAME@;
     public const string VERSION = @VERSION@;
     public const string INSTALL_PREFIX = @PREFIX@;

--- a/meson.build
+++ b/meson.build
@@ -62,17 +62,20 @@ install_data(
     rename: meson.project_name() + '.gschema.xml'
 )
 
-config_data = configuration_data()
-config_data.set('EXEC_NAME', meson.project_name())
-
 # Src build
 message('Src build')
 
 conf_data = configuration_data()
 conf_data.set_quoted('PROJECT_NAME', meson.project_name())
+conf_data.set_quoted('LOCALEDIR', get_option('prefix') / get_option('localedir'))
 conf_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
 conf_data.set_quoted('VERSION', meson.project_version())
 conf_data.set_quoted('PREFIX', get_option('prefix'))
+conf_file = configure_file(
+    input: 'config.vala.in',
+    output: '@BASENAME@',
+    configuration: conf_data
+)
 
 message('Configuring desktop entry: ' + meson.project_name() + '.desktop')
 
@@ -111,6 +114,7 @@ executable(
     meson.project_name(),
     code_files,
     asresources,
+    conf_file,
     dependencies: dependencies,
     install: true
 )

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -30,6 +30,13 @@ public class Badger.Application : Gtk.Application {
         );
     }
 
+    construct {
+        Intl.setlocale (LocaleCategory.ALL, "");
+        Intl.bindtextdomain (Constants.GETTEXT_PACKAGE, Constants.LOCALEDIR);
+        Intl.bind_textdomain_codeset (Constants.GETTEXT_PACKAGE, "UTF-8");
+        Intl.textdomain (Constants.GETTEXT_PACKAGE);
+    }
+
     protected override void activate () {
         stdout.printf ("\n✔️ Activated");
 


### PR DESCRIPTION
Fixes #71

Also remove unused configuration variable `EXEC_NAME` while we're here.

## Testing
Build and install the app from the source, and then try to run the app in French:

```
$ flatpak-builder builddir-fpk --user --install --force-clean com.github.elfenware.badger.yml
$ LANGUAGE=fr_FR.UTF-8 flatpak run com.github.elfenware.badger
```

### Before (main: 980f0bfa19756c1df5bd237a41f001cbad13b175)
The app is displayed in English although we specified French:

![スクリーンショット 2022-12-17 09 57 08](https://user-images.githubusercontent.com/26003928/208214710-36b6d754-cb42-42c5-a85c-a5d37e33ac9f.png)

### After (ryonakano/fix-translation-issue: e9634b3503ebd03440215baa1f41c285105e8348)
The app now follows the selected language:

![スクリーンショット 2022-12-17 09 52 11](https://user-images.githubusercontent.com/26003928/208214733-7a7f8f3c-b340-4adb-920e-66ed72afa74e.png)
