### PR TITLE
Do not translate app name

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -111,7 +111,7 @@ msgstr "Atmen:"
 #: src/MainWindow.vala:43
 #: src/MainWindow.vala:44
 msgid "Badger"
-msgstr "Dachs"
+msgstr "Badger"
 
 #: src/MainGrid.vala:48
 msgid "Reminders"

--- a/po/extra/de.po
+++ b/po/extra/de.po
@@ -15,7 +15,7 @@ msgstr ""
 #: data/com.github.elfenware.badger.desktop.in:4
 #: data/com.github.elfenware.badger.metainfo.xml.in:7
 msgid "Badger"
-msgstr "Dachs"
+msgstr "Badger"
 
 #: data/com.github.elfenware.badger.desktop.in:5
 msgid "Ergonomic Reminder"
@@ -225,93 +225,3 @@ msgstr "Erste Veröffentlichung 🎉️"
 msgid "Elfenware"
 msgstr "Elfenware"
 
-#~ msgid "Blink your eyes"
-#~ msgstr "Blinzeln Sie mit den Augen"
-
-#~ msgid "Look away from the screen and slowly blink your eyes for 10 seconds."
-#~ msgstr "Schauen Sie vom Bildschirm weg und blinzeln Sie langsam 10 Sekunden lang mit den Augen."
-
-#~ msgid "Eyes:"
-#~ msgstr "Die Augen:"
-
-#~ msgid "Stretch your fingers"
-#~ msgstr "Strecken Sie Ihre Finger"
-
-#~ msgid "Spread out your palm wide, then close it into a fist. Repeat 5 times."
-#~ msgstr "Breiten Sie Ihre Handfläche weit aus und schließen Sie sie dann zu einer Faust. Wiederholen Sie dies 5 Mal."
-
-#~ msgid "Fingers:"
-#~ msgstr "Die Finger:"
-
-#~ msgid "Stretch your arms"
-#~ msgstr "Strecken Sie Ihre Arme"
-
-#~ msgid "Stretch your arms, and twist your wrists for 10 seconds."
-#~ msgstr "Strecken Sie die Arme und verdrehen Sie die Handgelenke für 10 Sekunden."
-
-#~ msgid "Arms:"
-#~ msgstr "Die Arme:"
-
-#~ msgid "Stretch your legs"
-#~ msgstr "Die Beine vertreten"
-
-#~ msgid "Stand up, twist each ankle, and bend each knee."
-#~ msgstr "Stehen Sie auf, drehen Sie jedes Fußgelenk und beugen Sie jedes Knie."
-
-#~ msgid "Legs:"
-#~ msgstr "Die Beine:"
-
-#~ msgid "Turn your neck"
-#~ msgstr "Den Hals umdrehen"
-
-#~ msgid "Turn your head in all directions. Repeat 3 times."
-#~ msgstr "Drehen Sie den Kopf in alle Richtungen. Wiederholen Sie dies 3 Mal."
-
-#~ msgid "Neck:"
-#~ msgstr "Hals:"
-
-#~ msgid "Hydrate yourself"
-#~ msgstr "Hydratisieren Sie sich"
-
-#~ msgid "Drink a glass of water."
-#~ msgstr "Trinken Sie ein Glas Wasser."
-
-#~ msgid "Water:"
-#~ msgstr "Wasser:"
-
-#~ msgid "Watch your posture"
-#~ msgstr "Achten Sie auf Ihre Körperhaltung"
-
-#~ msgid "Make sure your back is straight."
-#~ msgstr "Achten Sie darauf, dass Ihr Rücken gerade ist."
-
-#~ msgid "Posture:"
-#~ msgstr "Körperhaltung:"
-
-#~ msgid "Focus on your breath"
-#~ msgstr "Konzentrieren Sie sich auf Ihren Atem"
-
-#~ msgid "Inhale and exhale deeply, thrice."
-#~ msgstr "Atme dreimal tief ein und aus."
-
-#~ msgid "Breath:"
-#~ msgstr "Atmen:"
-
-#~ msgid "Reminders"
-#~ msgstr "Mahnungen"
-
-#~ msgid "Decide how often Badger should remind you to relax these:"
-#~ msgstr "Entscheiden Sie, wie oft Badger Sie daran erinnern soll, diese zu entspannen:"
-
-#, c-format
-#~ msgid "%.0f min"
-#~ msgstr "%.0f min"
-
-#~ msgid "1 min"
-#~ msgstr "1 Minute"
-
-#~ msgid "30 min"
-#~ msgstr "30 min"
-
-#~ msgid "1 hour"
-#~ msgstr "1 Stunde"


### PR DESCRIPTION
I dont know why it was set as translatable string, and just kind of respected it, but since other translations do not, may as well be consistent.