### PR TITLE
Resize window according to toggle state

### DIFF
--- a/data/com.github.elfenware.badger.gschema.xml
+++ b/data/com.github.elfenware.badger.gschema.xml
@@ -77,15 +77,5 @@
     path="/com/github/elfenware/badger/state/"
     id="com.github.elfenware.badger.state"
     gettext-domain="com.github.elfenware.badger">
-    <key name="window-width" type="i">
-      <default>180</default>
-      <summary>The saved width of the window.</summary>
-      <description>The saved width of the window.</description>
-    </key>
-    <key name="window-height" type="i">
-      <default>200</default>
-      <summary>The saved height of the window.</summary>
-      <description>The saved height of the window.</description>
-    </key>
   </schema>
 </schemalist>

--- a/src/MainGrid.vala
+++ b/src/MainGrid.vala
@@ -20,6 +20,7 @@
 
 public class Badger.MainGrid : Gtk.Box {
     delegate void SetInterval (uint interval);
+    public Gtk.Revealer revealer;
 
     public MainGrid (Reminder[] reminders) {
         var settings = new GLib.Settings ("com.github.elfenware.badger.timers");
@@ -41,6 +42,7 @@ public class Badger.MainGrid : Gtk.Box {
                     halign = Gtk.Align.END,
                     hexpand = true,
                     valign = Gtk.Align.CENTER,
+                    margin_bottom = 18
         };
         settings.bind ("all", global_switch, "active", SettingsBindFlags.DEFAULT);
         var heading = new Granite.HeaderLabel (_ ("Reminders")) {
@@ -52,6 +54,12 @@ public class Badger.MainGrid : Gtk.Box {
         global_box.append (global_switch);
         append (global_box);
 
+        
+        // This is everything below the switch.
+        var scale_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+        scale_box.vexpand = true;
+
+
 
         /************************************************/
         /*               Label to explain               */
@@ -59,16 +67,16 @@ public class Badger.MainGrid : Gtk.Box {
 
         var subheading = new Gtk.Label (_ ("Decide how often Badger should remind you to relax these:")) {
             halign = Gtk.Align.START,
-            margin_top = 18,
-            margin_bottom = 6
+            margin_top = 12,
+            margin_bottom = 0
         };
         subheading.add_css_class (Granite.STYLE_CLASS_H4_LABEL);
         subheading.add_css_class ("title-4");
 
-        append (subheading);
+        scale_box.append (subheading);
 
         var marks = new Marks ();
-        append (marks);
+        scale_box.append (marks);
 
         HashTable<string, Gtk.Scale> scales = new HashTable<string, Gtk.Scale> (str_hash, str_equal);
 
@@ -96,9 +104,6 @@ public class Badger.MainGrid : Gtk.Box {
         /************************************************/
         /*               All the scales                 */
         /************************************************/
-
-        var scale_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
-        scale_box.vexpand = true;
 
         for (int index = 0; index < reminders.length; index++) {
             Reminder reminder = reminders[index];
@@ -161,7 +166,7 @@ public class Badger.MainGrid : Gtk.Box {
 
         }
 
-        append (scale_box);
+        
 
 
         /********************************************/
@@ -174,6 +179,20 @@ public class Badger.MainGrid : Gtk.Box {
             margin_bottom = 6
         };
         hey.add_css_class ("accent");
-        append (hey);
+        scale_box.append (hey);
+
+
+        /**************************************************/
+        /*               Scales revealer                  */
+        /**************************************************/
+        
+        // If the "all" flag is false, the switch is off, hide the scales 
+        Gtk.Revealer revealer = new Gtk.Revealer();
+        revealer.set_transition_type (Gtk.RevealerTransitionType.SLIDE_DOWN);
+        settings.bind ("all", revealer, "reveal_child", SettingsBindFlags.DEFAULT);
+
+        revealer.set_child(scale_box);
+        append (revealer);
+
     }
 }

--- a/src/MainGrid.vala
+++ b/src/MainGrid.vala
@@ -54,7 +54,6 @@ public class Badger.MainGrid : Gtk.Box {
         global_box.append (global_switch);
         append (global_box);
 
-        
         // This is everything below the switch.
         var scale_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
         scale_box.vexpand = true;
@@ -166,9 +165,6 @@ public class Badger.MainGrid : Gtk.Box {
 
         }
 
-        
-
-
         /********************************************/
         /*               DnD Label                  */
         /********************************************/
@@ -181,18 +177,14 @@ public class Badger.MainGrid : Gtk.Box {
         hey.add_css_class ("accent");
         scale_box.append (hey);
 
-
         /**************************************************/
         /*               Scales revealer                  */
         /**************************************************/
-        
+
         // If the "all" flag is false, the switch is off, hide the scales 
-        Gtk.Revealer revealer = new Gtk.Revealer();
+        this.revealer = new Gtk.Revealer ();
         revealer.set_transition_type (Gtk.RevealerTransitionType.SLIDE_DOWN);
-        settings.bind ("all", revealer, "reveal_child", SettingsBindFlags.DEFAULT);
-
-        revealer.set_child(scale_box);
+        revealer.set_child (scale_box);
         append (revealer);
-
     }
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -33,15 +33,15 @@ public class Badger.MainWindow : Gtk.Window {
 
     construct {
         Intl.setlocale ();
-        settings = new GLib.Settings ("com.github.elfenware.badger.state");
+        settings = new GLib.Settings ("com.github.elfenware.badger.timers");
 
-        set_default_size (
-            settings.get_int ("window-width"),
-            settings.get_int ("window-height")
-        );
+        // We cannot resize window if it is allowed to change
+        set_size_request (12, 12);
+        set_resizable (false);
 
-        set_title (_("Badger"));
-        Gtk.Label title_widget = new Gtk.Label (_("Badger"));
+
+        set_title ("Badger");
+        Gtk.Label title_widget = new Gtk.Label (this.get_title ());
         title_widget.add_css_class (Granite.STYLE_CLASS_TITLE_LABEL);
 
         this.headerbar = new Gtk.HeaderBar ();
@@ -59,34 +59,21 @@ public class Badger.MainWindow : Gtk.Window {
 
         set_child (handle);
 
-        var global_switch = new GLib.Settings ("com.github.elfenware.badger.timers");
+        // Avoid showing the window without content despite toggle off.
+        main.revealer.reveal_child = settings.get_boolean ("all");
 
-        // Resize window when content gets hidden
-        global_switch.notify["all"].connect (() => {
-            if (global_switch.get_boolean ("all") == false) {
-                this.height_request = 0;
-                this.default_height = 0;
-                print ("eugh");
-            }
-        });
-
-        // save state
-        close_request.connect (e => {
-            return before_destroy ();
-        });
+        // Resize window accordingly to state of global switch
+        settings.changed["all"].connect ( on_toggle_changed);
     }
 
+    private void on_toggle_changed () {
+        debug ("\nToggle changed!");
+        main.revealer.reveal_child = settings.get_boolean ("all");
 
-    // save state
-    private bool before_destroy () {
-        int width, height;
-
-        get_default_size (out width, out height);
-
-        settings.set_int ("window-width", width);
-        settings.set_int ("window-height", height);
-
-        hide ();
-        return true;
+        if (!settings.get_boolean ("all")) {
+            debug ("\nToggle is off! Resizing window");
+            set_size_request (12, 12);
+            queue_resize ();
+        }
     }
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -32,7 +32,7 @@ public class Badger.MainWindow : Gtk.Window {
     }
 
     construct {
-            Intl.setlocale ();
+        Intl.setlocale ();
         settings = new GLib.Settings ("com.github.elfenware.badger.state");
 
         set_default_size (
@@ -58,6 +58,17 @@ public class Badger.MainWindow : Gtk.Window {
         };
 
         set_child (handle);
+
+        var global_switch = new GLib.Settings ("com.github.elfenware.badger.timers");
+
+        // Resize window when content gets hidden
+        global_switch.notify["all"].connect (() => {
+            if (global_switch.get_boolean ("all") == false) {
+                this.height_request = 0;
+                this.default_height = 0;
+                print ("eugh");
+            }
+        });
 
         // save state
         close_request.connect (e => {


### PR DESCRIPTION
Fixes https://github.com/elfenware/badger/issues/95

it appears, GTK refuses to do much in the way of resizing windows programmatically, if you allow the user to resize windows

so this branch removes the ability to resize badger, forcing it into a specific size
but also allow for the neateness to hide/show the sliders depending on if you want reminders or not