### PR TITLE
withdraw previous notif of same kind

### DIFF
--- a/src/Reminder.vala
+++ b/src/Reminder.vala
@@ -68,6 +68,7 @@ public class Badger.Reminder : GLib.Object {
 
     public bool remind () {
         if (global_active && checkbox_active) {
+            app.withdraw_notification (name);
             app.send_notification (name, notification);
         }
         return true;


### PR DESCRIPTION
-Fixes https://github.com/elfenware/badger/issues/114.
For each type of reminder, badger removes the older one right before notifying anew. So you never have history being cluttered by ten times the same thing.

(Darshak, my man, do we also want Badger to clean up older of its notifications upon startup? If the ones from yesterday are still here, it may be better to have badger just straight up tidy)