### PR TITLE
prevent app from lingering in the background

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -86,7 +86,6 @@ public class Badger.MainWindow : Gtk.Window {
     // Avoid a bug whence reopened windows cannot be closed
     private bool before_destroy () {
         debug ("Window closed!");
-        hide ();
 
         if (!settings.get_boolean ("all")) {
             debug ("All reminders are disabled, Badger will now go to sleep");

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -84,7 +84,12 @@ public class Badger.MainWindow : Gtk.Window {
 
     // Avoid a bug whence reopened windows cannot be closed
     private bool before_destroy () {
+        debug ("Window closed!");
         hide ();
+        if (!settings.get_boolean ("all")) {
+            debug ("All reminders are disabled, Badger will now go to sleep");
+            application.quit ();
+        };
         return true;
     }
 }


### PR DESCRIPTION
Make badger quit when everything is disabled
Now eOS shows apps running in the background. It does not make sense to have badger hog like twenty whole megabytes when it isnt doing anything, and add noise when users check on what is actually doing something in the back